### PR TITLE
Remove commented contact_links from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: false
-# contact_links:
-#   - name: Security reports
-#     url: https://github.com/chainapsis/oko/security/policy
-#     about: Please report vulnerabilities via our security policy.


### PR DESCRIPTION
Even if there is no security template in config.yml, if security.md exists, the vulnerability reporting section is automatically added to the issue template. Therefore, I removed comments.