### PR TITLE
demo_web: activate Solana (Ed25519) SDK and widgets

### DIFF
--- a/apps/demo_web/src/components/oko_provider/use_oko.ts
+++ b/apps/demo_web/src/components/oko_provider/use_oko.ts
@@ -7,17 +7,19 @@ import { useSDKState } from "@oko-wallet-demo-web/state/sdk";
 export function useInitOko() {
   const initOkoCosmos = useSDKState((state) => state.initOkoCosmos);
   const initOkoEth = useSDKState((state) => state.initOkoEth);
-  // const initOkoSol = useSDKState((state) => state.initOkoSol);
+  const initOkoSol = useSDKState((state) => state.initOkoSol);
 
   const isInitialized = useSDKState(
-    (state) => state.oko_cosmos !== null && state.oko_eth !== null,
-    // state.oko_sol !== null,
+    (state) =>
+      state.oko_cosmos !== null &&
+      state.oko_eth !== null &&
+      state.oko_sol !== null,
   );
 
   useEffect(() => {
     initOkoCosmos();
     initOkoEth();
-    // initOkoSol();
+    initOkoSol();
   }, []);
 
   return { isInitialized };

--- a/apps/demo_web/src/components/preview_panel/preview_panel.tsx
+++ b/apps/demo_web/src/components/preview_panel/preview_panel.tsx
@@ -12,18 +12,17 @@ import { CosmosOnchainSignWidget } from "@oko-wallet-demo-web/components/widgets
 import { CosmosOffChainSignWidget } from "@oko-wallet-demo-web/components/widgets/cosmos_offchain_sign_widget/cosmos_offchain_sign_widget";
 import { EthereumOnchainSignWidget } from "@oko-wallet-demo-web/components/widgets/ethereum_onchain_sign_widget/ethereum_onchain_sign_widget";
 import { EthereumOffchainSignWidget } from "@oko-wallet-demo-web/components/widgets/ethereum_offchain_sign_widget/ethereum_offchain_sign_widget";
-// import { SolanaOffchainSignWidget } from "@oko-wallet-demo-web/components/widgets/solana_offchain_sign_widget/solana_offchain_sign_widget";
-// TODO: refactor this @chemonoworld @Ryz0nd
-// import { SolanaOnchainSignWidget } from "@oko-wallet-demo-web/components/widgets/solana_onchain_sign_widget/solana_onchain_sign_widget";
+import { SolanaOffchainSignWidget } from "@oko-wallet-demo-web/components/widgets/solana_offchain_sign_widget/solana_offchain_sign_widget";
+import { SolanaOnchainSignWidget } from "@oko-wallet-demo-web/components/widgets/solana_onchain_sign_widget/solana_onchain_sign_widget";
 import { useUserInfoState } from "@oko-wallet-demo-web/state/user_info";
 import { useSDKState } from "@oko-wallet-demo-web/state/sdk";
 
 export const PreviewPanel: FC = () => {
   const isLazyInitialized = useSDKState(
-    (st) => st.isCosmosLazyInitialized && st.isEthLazyInitialized,
-    // TODO: refactor this @chemonoworld @Ryz0nd
-    // &&
-    // st.isSolLazyInitialized,
+    (st) =>
+      st.isCosmosLazyInitialized &&
+      st.isEthLazyInitialized &&
+      st.isSolLazyInitialized,
   );
 
   const isSignedIn = useUserInfoState((state) => state.isSignedIn);
@@ -51,9 +50,8 @@ export const PreviewPanel: FC = () => {
               )}
               {isSignedIn && (
                 <div className={styles.col}>
-                  {/* TODO: refactor this @chemonoworld @Ryz0nd */}
-                  {/* <SolanaOffchainSignWidget /> */}
-                  {/* <SolanaOnchainSignWidget /> */}
+                  <SolanaOffchainSignWidget />
+                  <SolanaOnchainSignWidget />
                 </div>
               )}
             </>

--- a/apps/demo_web/src/components/widgets/account_widget/account_info_widget.tsx
+++ b/apps/demo_web/src/components/widgets/account_widget/account_info_widget.tsx
@@ -16,7 +16,8 @@ import type { LoginMethod } from "@oko-wallet-demo-web/types/login";
 export type AccountInfoWidgetProps = {
   type: LoginMethod;
   email: string;
-  publicKey: string;
+  publicKeySecp256k1: string;
+  publicKeyEd25519: string | null;
   name: string | null;
   onSignOut: () => void;
 };
@@ -24,7 +25,8 @@ export type AccountInfoWidgetProps = {
 export const AccountInfoWidget: FC<AccountInfoWidgetProps> = ({
   type,
   email,
-  publicKey,
+  publicKeySecp256k1,
+  publicKeyEd25519,
   name,
   onSignOut,
 }) => {
@@ -56,12 +58,35 @@ export const AccountInfoWidget: FC<AccountInfoWidgetProps> = ({
             color="tertiary"
             className={styles.label}
           >
-            Public Key
+            Public Key (secp256k1)
           </Typography>
           <Typography size="sm" weight="medium" className={styles.publicKey}>
-            {publicKey}
+            {publicKeySecp256k1}
           </Typography>
         </div>
+
+        {publicKeyEd25519 && (
+          <>
+            <Spacing height={12} />
+            <div className={styles.publicKeyCol}>
+              <Typography
+                size="xs"
+                weight="semibold"
+                color="tertiary"
+                className={styles.label}
+              >
+                Public Key (ed25519)
+              </Typography>
+              <Typography
+                size="sm"
+                weight="medium"
+                className={styles.publicKey}
+              >
+                {publicKeyEd25519}
+              </Typography>
+            </div>
+          </>
+        )}
 
         <Spacing height={12} />
 

--- a/apps/demo_web/src/components/widgets/account_widget/account_widget.tsx
+++ b/apps/demo_web/src/components/widgets/account_widget/account_widget.tsx
@@ -28,7 +28,10 @@ export const AccountWidget: FC<AccountWidgetProps> = () => {
     status: "ready",
   });
   const email = useUserInfoState((state) => state.email);
-  const publicKey = useUserInfoState((state) => state.publicKey);
+  const publicKeySecp256k1 = useUserInfoState(
+    (state) => state.publicKeySecp256k1,
+  );
+  const publicKeyEd25519 = useUserInfoState((state) => state.publicKeyEd25519);
   const name = useUserInfoState((state) => state.name);
   const authType = useUserInfoState((state) => state.authType);
   const isSignedIn = useUserInfoState((state) => state.isSignedIn);
@@ -118,7 +121,8 @@ export const AccountWidget: FC<AccountWidgetProps> = () => {
       <AccountInfoWidget
         type={displayLoginMethod}
         email={email || ""}
-        publicKey={publicKey || ""}
+        publicKeySecp256k1={publicKeySecp256k1 || ""}
+        publicKeyEd25519={publicKeyEd25519}
         name={name}
         onSignOut={handleSignOut}
       />

--- a/apps/demo_web/src/components/widgets/address_widget/address_row.tsx
+++ b/apps/demo_web/src/components/widgets/address_widget/address_row.tsx
@@ -4,10 +4,18 @@ import { Tooltip } from "@oko-wallet/oko-common-ui/tooltip";
 
 import styles from "./address_row.module.scss";
 
+const chainConfig: Record<
+  AddressRowProps["chain"],
+  { label: string; prefix: string }
+> = {
+  ethereum: { label: "Ethereum", prefix: "0x" },
+  cosmos: { label: "Cosmos Hub", prefix: "cosmos1" },
+  solana: { label: "Solana", prefix: "" },
+};
+
 export const AddressRow: FC<AddressRowProps> = ({ icon, chain, address }) => {
   const isLoggedIn = !!address;
-  const label = chain === "ethereum" ? "Ethereum" : "Cosmos Hub";
-  const prefix = chain === "ethereum" ? "0x" : "cosmos1";
+  const { label, prefix } = chainConfig[chain];
 
   const renderChainLabel = () => (
     <div className={isLoggedIn ? styles.chainLabelChip : styles.chainLabel}>
@@ -63,6 +71,6 @@ export const AddressRow: FC<AddressRowProps> = ({ icon, chain, address }) => {
 
 export interface AddressRowProps {
   icon: ReactElement;
-  chain: "ethereum" | "cosmos";
+  chain: "ethereum" | "cosmos" | "solana";
   address?: string;
 }

--- a/apps/demo_web/src/components/widgets/address_widget/address_widget.tsx
+++ b/apps/demo_web/src/components/widgets/address_widget/address_widget.tsx
@@ -1,6 +1,7 @@
 import { useState, type FC } from "react";
 import { CosmosIcon } from "@oko-wallet/oko-common-ui/icons/cosmos_icon";
 import { EthereumBlueIcon } from "@oko-wallet/oko-common-ui/icons/ethereum_blue_icon";
+import { SolanaIcon } from "@oko-wallet/oko-common-ui/icons/solana_icon";
 import { WalletIcon } from "@oko-wallet/oko-common-ui/icons/wallet";
 import { Spacing } from "@oko-wallet/oko-common-ui/spacing";
 import { Typography } from "@oko-wallet/oko-common-ui/typography";
@@ -15,7 +16,7 @@ import { useGetChainInfos } from "@oko-wallet-demo-web/hooks/use_get_chain_infos
 
 export const AddressWidget: FC<AddressWidgetProps> = ({}) => {
   const [showModal, setShowModal] = useState(false);
-  const { cosmosAddress, ethAddress } = useAddresses();
+  const { cosmosAddress, ethAddress, solanaAddress } = useAddresses();
 
   const { data: chains } = useGetChainInfos();
 
@@ -54,6 +55,13 @@ export const AddressWidget: FC<AddressWidgetProps> = ({}) => {
             icon={<CosmosIcon />}
             chain="cosmos"
             address={formatAddress(cosmosAddress)}
+          />
+          <Spacing height={12} />
+
+          <AddressRow
+            icon={<SolanaIcon />}
+            chain="solana"
+            address={formatAddress(solanaAddress)}
           />
           <Spacing height={12} />
 

--- a/apps/demo_web/src/components/widgets/solana_offchain_sign_widget/solana_offchain_sign_widget.tsx
+++ b/apps/demo_web/src/components/widgets/solana_offchain_sign_widget/solana_offchain_sign_widget.tsx
@@ -1,38 +1,36 @@
-// TODO: refactor this widget @chemonoworld @Ryz0nd
+import { SolanaIcon } from "@oko-wallet/oko-common-ui/icons/solana_icon";
 
-// import { SolanaIcon } from "@oko-wallet/oko-common-ui/icons/solana_icon";
+import { SignWidget } from "@oko-wallet-demo-web/components/widgets/sign_widget/sign_widget";
+import { useSDKState } from "@oko-wallet-demo-web/state/sdk";
 
-// import { SignWidget } from "@oko-wallet-demo-web/components/widgets/sign_widget/sign_widget";
-// import { useSDKState } from "@oko-wallet-demo-web/state/sdk";
+export const SolanaOffchainSignWidget = () => {
+  const okoSol = useSDKState((state) => state.oko_sol);
 
-// export const SolanaOffchainSignWidget = () => {
-//   const okoSol = useSDKState((state) => state.oko_sol);
+  const handleClickSolOffchainSign = async () => {
+    if (okoSol === null) {
+      throw new Error("okoSol is not initialized");
+    }
 
-//   const handleClickSolOffchainSign = async () => {
-//     if (okoSol === null) {
-//       throw new Error("okoSol is not initialized");
-//     }
+    // Connect if not already connected
+    if (!okoSol.connected) {
+      await okoSol.connect();
+    }
 
-//     // Connect if not already connected
-//     if (!okoSol.connected) {
-//       await okoSol.connect();
-//     }
+    const message = "Welcome to Oko! Try generating an Ed25519 MPC signature.";
+    const messageBytes = new TextEncoder().encode(message);
 
-//     const message = "Welcome to Oko! Try generating an Ed25519 MPC signature.";
-//     const messageBytes = new TextEncoder().encode(message);
+    const signature = await okoSol.signMessage(messageBytes);
 
-//     const signature = await okoSol.signMessage(messageBytes);
+    // Log signature for demo purposes
+    console.log("Solana signature:", Buffer.from(signature).toString("hex"));
+  };
 
-//     // Log signature for demo purposes
-//     console.log("Solana signature:", Buffer.from(signature).toString("hex"));
-//   };
-
-//   return (
-//     <SignWidget
-//       chain="Solana"
-//       chainIcon={<SolanaIcon />}
-//       signType="offchain"
-//       signButtonOnClick={handleClickSolOffchainSign}
-//     />
-//   );
-// };
+  return (
+    <SignWidget
+      chain="Solana"
+      chainIcon={<SolanaIcon />}
+      signType="offchain"
+      signButtonOnClick={handleClickSolOffchainSign}
+    />
+  );
+};

--- a/apps/demo_web/src/components/widgets/solana_onchain_sign_widget/solana_onchain_sign_widget.tsx
+++ b/apps/demo_web/src/components/widgets/solana_onchain_sign_widget/solana_onchain_sign_widget.tsx
@@ -1,130 +1,128 @@
-// TODO: refactor this widget @chemonoworld @Ryz0nd
+import { useCallback, useState } from "react";
+import {
+  Connection,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionMessage,
+  VersionedTransaction,
+  LAMPORTS_PER_SOL,
+} from "@solana/web3.js";
+import { SolanaIcon } from "@oko-wallet/oko-common-ui/icons/solana_icon";
+import { Checkbox } from "@oko-wallet/oko-common-ui/checkbox";
 
-// import { useCallback, useState } from "react";
-// import {
-//   Connection,
-//   PublicKey,
-//   SystemProgram,
-//   Transaction,
-//   TransactionMessage,
-//   VersionedTransaction,
-//   LAMPORTS_PER_SOL,
-// } from "@solana/web3.js";
-// import { SolanaIcon } from "@oko-wallet/oko-common-ui/icons/solana_icon";
-// import { Checkbox } from "@oko-wallet/oko-common-ui/checkbox";
+import styles from "./solana_onchain_sign_widget.module.scss";
+import { SignWidget } from "@oko-wallet-demo-web/components/widgets/sign_widget/sign_widget";
+import { useSDKState } from "@oko-wallet-demo-web/state/sdk";
 
-// import styles from "./solana_onchain_sign_widget.module.scss";
-// import { SignWidget } from "@oko-wallet-demo-web/components/widgets/sign_widget/sign_widget";
-// import { useSDKState } from "@oko-wallet-demo-web/state/sdk";
+const SOLANA_RPC_URL = "https://api.devnet.solana.com";
 
-// const SOLANA_RPC_URL = "https://api.devnet.solana.com";
+export const SolanaOnchainSignWidget = () => {
+  const okoSol = useSDKState((state) => state.oko_sol);
+  const [isLegacy, setIsLegacy] = useState(false);
 
-// export const SolanaOnchainSignWidget = () => {
-//   const okoSol = useSDKState((state) => state.oko_sol);
-//   const [isLegacy, setIsLegacy] = useState(false);
+  const handleClickSolOnchainSignV0 = useCallback(async () => {
+    if (okoSol === null) {
+      throw new Error("okoSol is not initialized");
+    }
 
-//   const handleClickSolOnchainSignV0 = useCallback(async () => {
-//     if (okoSol === null) {
-//       throw new Error("okoSol is not initialized");
-//     }
+    if (!okoSol.connected) {
+      await okoSol.connect();
+    }
 
-//     if (!okoSol.connected) {
-//       await okoSol.connect();
-//     }
+    if (!okoSol.publicKey) {
+      throw new Error("No public key available");
+    }
 
-//     if (!okoSol.publicKey) {
-//       throw new Error("No public key available");
-//     }
+    const connection = new Connection(SOLANA_RPC_URL);
 
-//     const connection = new Connection(SOLANA_RPC_URL);
+    const toAddress = new PublicKey("11111111111111111111111111111111");
 
-//     const toAddress = new PublicKey("11111111111111111111111111111111");
+    const { blockhash } = await connection.getLatestBlockhash();
 
-//     const { blockhash } = await connection.getLatestBlockhash();
+    const instructions = [
+      SystemProgram.transfer({
+        fromPubkey: okoSol.publicKey,
+        toPubkey: toAddress,
+        lamports: 0.001 * LAMPORTS_PER_SOL,
+      }),
+    ];
 
-//     const instructions = [
-//       SystemProgram.transfer({
-//         fromPubkey: okoSol.publicKey,
-//         toPubkey: toAddress,
-//         lamports: 0.001 * LAMPORTS_PER_SOL,
-//       }),
-//     ];
+    const messageV0 = new TransactionMessage({
+      payerKey: okoSol.publicKey,
+      recentBlockhash: blockhash,
+      instructions,
+    }).compileToV0Message();
 
-//     const messageV0 = new TransactionMessage({
-//       payerKey: okoSol.publicKey,
-//       recentBlockhash: blockhash,
-//       instructions,
-//     }).compileToV0Message();
+    const versionedTransaction = new VersionedTransaction(messageV0);
 
-//     const versionedTransaction = new VersionedTransaction(messageV0);
+    const signedTransaction =
+      await okoSol.signTransaction(versionedTransaction);
 
-//     const signedTransaction =
-//       await okoSol.signTransaction(versionedTransaction);
+    console.log(
+      "Solana v0 signed transaction:",
+      Buffer.from(signedTransaction.signatures[0]).toString("hex"),
+    );
+  }, [okoSol]);
 
-//     console.log(
-//       "Solana v0 signed transaction:",
-//       Buffer.from(signedTransaction.signatures[0]).toString("hex"),
-//     );
-//   }, [okoSol]);
+  const handleClickSolOnchainSignLegacy = useCallback(async () => {
+    if (okoSol === null) {
+      throw new Error("okoSol is not initialized");
+    }
 
-//   const handleClickSolOnchainSignLegacy = useCallback(async () => {
-//     if (okoSol === null) {
-//       throw new Error("okoSol is not initialized");
-//     }
+    if (!okoSol.connected) {
+      await okoSol.connect();
+    }
 
-//     if (!okoSol.connected) {
-//       await okoSol.connect();
-//     }
+    if (!okoSol.publicKey) {
+      throw new Error("No public key available");
+    }
 
-//     if (!okoSol.publicKey) {
-//       throw new Error("No public key available");
-//     }
+    const connection = new Connection(SOLANA_RPC_URL);
 
-//     const connection = new Connection(SOLANA_RPC_URL);
+    const toAddress = new PublicKey("11111111111111111111111111111111");
 
-//     const toAddress = new PublicKey("11111111111111111111111111111111");
+    const transaction = new Transaction().add(
+      SystemProgram.transfer({
+        fromPubkey: okoSol.publicKey,
+        toPubkey: toAddress,
+        lamports: 0.001 * LAMPORTS_PER_SOL,
+      }),
+    );
 
-//     const transaction = new Transaction().add(
-//       SystemProgram.transfer({
-//         fromPubkey: okoSol.publicKey,
-//         toPubkey: toAddress,
-//         lamports: 0.001 * LAMPORTS_PER_SOL,
-//       }),
-//     );
+    const { blockhash } = await connection.getLatestBlockhash();
+    transaction.recentBlockhash = blockhash;
+    transaction.feePayer = okoSol.publicKey;
 
-//     const { blockhash } = await connection.getLatestBlockhash();
-//     transaction.recentBlockhash = blockhash;
-//     transaction.feePayer = okoSol.publicKey;
+    const signedTransaction = await okoSol.signTransaction(transaction);
 
-//     const signedTransaction = await okoSol.signTransaction(transaction);
+    console.log(
+      "Solana legacy signed transaction:",
+      signedTransaction.signatures.map((sig) =>
+        sig.signature ? Buffer.from(sig.signature).toString("hex") : null,
+      ),
+    );
+  }, [okoSol]);
 
-//     console.log(
-//       "Solana legacy signed transaction:",
-//       signedTransaction.signatures.map((sig) =>
-//         sig.signature ? Buffer.from(sig.signature).toString("hex") : null,
-//       ),
-//     );
-//   }, [okoSol]);
-
-//   return (
-//     <SignWidget
-//       chain="Solana"
-//       chainIcon={<SolanaIcon />}
-//       signType="onchain"
-//       signButtonOnClick={
-//         isLegacy ? handleClickSolOnchainSignLegacy : handleClickSolOnchainSignV0
-//       }
-//       renderBottom={() => (
-//         <div className={styles.checkboxContainer}>
-//           <Checkbox
-//             size="sm"
-//             id="set-tx-version"
-//             checked={isLegacy}
-//             onChange={() => setIsLegacy((prevState) => !prevState)}
-//             label="Legacy Transaction"
-//           />
-//         </div>
-//       )}
-//     />
-//   );
-// };
+  return (
+    <SignWidget
+      chain="Solana"
+      chainIcon={<SolanaIcon />}
+      signType="onchain"
+      signButtonOnClick={
+        isLegacy ? handleClickSolOnchainSignLegacy : handleClickSolOnchainSignV0
+      }
+      renderBottom={() => (
+        <div className={styles.checkboxContainer}>
+          <Checkbox
+            size="sm"
+            id="set-tx-version"
+            checked={isLegacy}
+            onChange={() => setIsLegacy((prevState) => !prevState)}
+            label="Legacy Transaction"
+          />
+        </div>
+      )}
+    />
+  );
+};

--- a/apps/demo_web/src/hooks/wallet.ts
+++ b/apps/demo_web/src/hooks/wallet.ts
@@ -58,18 +58,14 @@ export function useAddresses() {
 
         if (okoSol) {
           promises.push(
-            (async () => {
-              try {
-                if (!okoSol.connected) {
-                  await okoSol.connect();
-                }
+            Promise.resolve()
+              .then(() => (!okoSol.connected ? okoSol.connect() : undefined))
+              .then(() => {
                 if (okoSol.publicKey && isSignedRef.current) {
                   setSolanaAddress(okoSol.publicKey.toBase58());
                 }
-              } catch (err) {
-                console.error("Failed to get Solana address:", err);
-              }
-            })(),
+              })
+              .catch((err) => console.error("Failed to get Solana address:", err)),
           );
         }
 

--- a/apps/demo_web/src/hooks/wallet.ts
+++ b/apps/demo_web/src/hooks/wallet.ts
@@ -65,7 +65,9 @@ export function useAddresses() {
                   setSolanaAddress(okoSol.publicKey.toBase58());
                 }
               })
-              .catch((err) => console.error("Failed to get Solana address:", err)),
+              .catch((err) =>
+                console.error("Failed to get Solana address:", err),
+              ),
           );
         }
 

--- a/apps/demo_web/src/hooks/wallet.ts
+++ b/apps/demo_web/src/hooks/wallet.ts
@@ -60,7 +60,6 @@ export function useAddresses() {
           promises.push(
             (async () => {
               try {
-                // lazyInit에서 이미 connected=true일 수 있음
                 if (!okoSol.connected) {
                   await okoSol.connect();
                 }

--- a/apps/demo_web/src/state/sdk.ts
+++ b/apps/demo_web/src/state/sdk.ts
@@ -166,6 +166,8 @@ export const useSDKState = create(
           console.log("Sol SDK initialized");
 
           const okoSol = initRes.data;
+          setupSolListener(okoSol);
+
           set({
             oko_sol: okoSol,
             isSolInitializing: false,
@@ -221,4 +223,17 @@ function setupCosmosListener(cosmosSDK: OkoCosmosWalletInterface) {
       },
     });
   }
+}
+
+function setupSolListener(solSDK: OkoSolWalletInterface) {
+  const setPublicKeyEd25519 = useUserInfoState.getState().setPublicKeyEd25519;
+
+  console.log("[Demo] Setting up Sol accountChanged listener");
+  solSDK.on("accountChanged", () => {
+    const ed25519Key = solSDK.state.publicKeyRaw;
+    console.log("[Demo] Sol accountChanged event received:", {
+      ed25519Key: ed25519Key ? "exists" : "null",
+    });
+    setPublicKeyEd25519(ed25519Key);
+  });
 }

--- a/apps/demo_web/src/state/sdk.ts
+++ b/apps/demo_web/src/state/sdk.ts
@@ -8,10 +8,10 @@ import {
   OkoEthWallet,
   type OkoEthWalletInterface,
 } from "@oko-wallet/oko-sdk-eth";
-// import {
-//   OkoSolWallet,
-//   type OkoSolWalletInterface,
-// } from "@oko-wallet/oko-sdk-sol";
+import {
+  OkoSolWallet,
+  type OkoSolWalletInterface,
+} from "@oko-wallet/oko-sdk-sol";
 import { create } from "zustand";
 import { combine } from "zustand/middleware";
 
@@ -20,7 +20,7 @@ import { useUserInfoState } from "@oko-wallet-demo-web/state/user_info";
 interface SDKState {
   oko_eth: OkoEthWalletInterface | null;
   oko_cosmos: OkoCosmosWalletInterface | null;
-  // oko_sol: OkoSolWalletInterface | null;
+  oko_sol: OkoSolWalletInterface | null;
 
   isEthInitializing: boolean;
   isEthLazyInitialized: boolean;
@@ -35,13 +35,13 @@ interface SDKState {
 interface SDKActions {
   initOkoEth: () => Promise<OkoEthWalletInterface | null>;
   initOkoCosmos: () => Promise<OkoCosmosWalletInterface | null>;
-  // initOkoSol: () => Promise<OkoSolWalletInterface | null>;
+  initOkoSol: () => Promise<OkoSolWalletInterface | null>;
 }
 
 const initialState: SDKState = {
   oko_eth: null,
   oko_cosmos: null,
-  // oko_sol: null,
+  oko_sol: null,
 
   isEthInitializing: false,
   isEthLazyInitialized: false,
@@ -145,10 +145,10 @@ export const useSDKState = create(
     initOkoSol: async () => {
       const state = get();
 
-      // if (state.oko_sol || state.isSolInitializing) {
-      //   console.log("Sol SDK already initialized or initializing, skipping...");
-      //   return state.oko_sol;
-      // }
+      if (state.oko_sol || state.isSolInitializing) {
+        console.log("Sol SDK already initialized or initializing, skipping...");
+        return state.oko_sol;
+      }
 
       try {
         console.log("Initializing Sol SDK...");
@@ -156,39 +156,39 @@ export const useSDKState = create(
           isSolInitializing: true,
         });
 
-        // const initRes = OkoSolWallet.init({
-        //   api_key:
-        //     "72bd2afd04374f86d563a40b814b7098e5ad6c7f52d3b8f84ab0c3d05f73ac6c",
-        //   sdk_endpoint: process.env.NEXT_PUBLIC_OKO_SDK_ENDPOINT,
-        // });
+        const initRes = OkoSolWallet.init({
+          api_key:
+            "72bd2afd04374f86d563a40b814b7098e5ad6c7f52d3b8f84ab0c3d05f73ac6c",
+          sdk_endpoint: process.env.NEXT_PUBLIC_OKO_SDK_ENDPOINT,
+        });
 
-        // if (initRes.success) {
-        //   console.log("Sol SDK initialized");
+        if (initRes.success) {
+          console.log("Sol SDK initialized");
 
-        //   const okoSol = initRes.data;
-        //   set({
-        //     // oko_sol: okoSol,
-        //     isSolInitializing: false,
-        //   });
+          const okoSol = initRes.data;
+          set({
+            oko_sol: okoSol,
+            isSolInitializing: false,
+          });
 
-        //   try {
-        //     await okoSol.waitUntilInitialized;
-        //     console.log("Sol SDK lazy initialized");
-        //     set({
-        //       isSolLazyInitialized: true,
-        //     });
-        //   } catch (e) {
-        //     console.error("Sol SDK lazy init failed:", e);
-        //     set({ isSolLazyInitialized: true }); // Still mark as done to not block
-        //   }
+          try {
+            await okoSol.waitUntilInitialized;
+            console.log("Sol SDK lazy initialized");
+            set({
+              isSolLazyInitialized: true,
+            });
+          } catch (e) {
+            console.error("Sol SDK lazy init failed:", e);
+            set({ isSolLazyInitialized: true }); // Still mark as done to not block
+          }
 
-        //   return okoSol;
-        // } else {
-        //   console.error("Sol sdk init fail, err: %s", initRes.err);
-        //   set({ isSolInitializing: false, isSolLazyInitialized: true });
+          return okoSol;
+        } else {
+          console.error("Sol sdk init fail, err: %s", initRes.err);
+          set({ isSolInitializing: false, isSolLazyInitialized: true });
 
-        //   return null;
-        // }
+          return null;
+        }
       } catch (e) {
         console.error("Sol SDK init error:", e);
         set({ isSolInitializing: false, isSolLazyInitialized: true });

--- a/apps/demo_web/src/state/user_info.ts
+++ b/apps/demo_web/src/state/user_info.ts
@@ -5,7 +5,8 @@ import { combine } from "zustand/middleware";
 interface UserInfoState {
   authType: AuthType | null;
   email: string | null;
-  publicKey: string | null;
+  publicKeySecp256k1: string | null;
+  publicKeyEd25519: string | null;
   name: string | null;
   isSignedIn: boolean;
 }
@@ -15,8 +16,10 @@ interface UserInfoActions {
     authType: AuthType | null;
     email: string | null;
     publicKey: string | null;
+    publicKeyEd25519?: string | null;
     name?: string | null;
   }) => void;
+  setPublicKeyEd25519: (publicKeyEd25519: string | null) => void;
   clearUserInfo: () => void;
 }
 
@@ -25,7 +28,8 @@ export const useUserInfoState = create(
     {
       authType: null,
       email: null,
-      publicKey: null,
+      publicKeySecp256k1: null,
+      publicKeyEd25519: null,
       name: null,
       isSignedIn: false,
     },
@@ -34,16 +38,21 @@ export const useUserInfoState = create(
         set({
           authType: info.authType,
           email: info.email ?? null,
-          publicKey: info.publicKey,
+          publicKeySecp256k1: info.publicKey,
+          publicKeyEd25519: info.publicKeyEd25519 ?? null,
           name: info.name ?? null,
           isSignedIn: !!info.publicKey,
         });
+      },
+      setPublicKeyEd25519: (publicKeyEd25519) => {
+        set({ publicKeyEd25519 });
       },
       clearUserInfo: () => {
         set({
           authType: null,
           email: null,
-          publicKey: null,
+          publicKeySecp256k1: null,
+          publicKeyEd25519: null,
           name: null,
           isSignedIn: false,
         });

--- a/backend/tss_api/src/api/v2/keygen/index.ts
+++ b/backend/tss_api/src/api/v2/keygen/index.ts
@@ -469,14 +469,14 @@ export async function runKeygenEd25519(
       return {
         success: false,
         code: "UNKNOWN_ERROR",
-        msg: `getWalletByPublicKey error: ${walletByPublicKeyRes.err}`,
+        msg: `getWalletByPublicKey (ed25519) error: ${walletByPublicKeyRes.err}`,
       };
     }
     if (walletByPublicKeyRes.data !== null) {
       return {
         success: false,
         code: "DUPLICATE_PUBLIC_KEY",
-        msg: `Duplicate public key: ${ed25519PublicKeyHex}`,
+        msg: `Duplicate ed25519 public key: ${ed25519PublicKeyHex}`,
       };
     }
 

--- a/crypto/tecdsa/api_lib/src/index.ts
+++ b/crypto/tecdsa/api_lib/src/index.ts
@@ -51,7 +51,7 @@ import {
   type SignInResponse,
   type SignInResponseV2,
 } from "@oko-wallet/oko-types/user";
-import type { KeygenBodyV2 } from "@oko-wallet/oko-types/tss";
+import type { KeygenRequestBodyV2 } from "@oko-wallet/oko-types/tss";
 import {
   type ErrorCode,
   type OkoApiErrorResponse,
@@ -198,7 +198,7 @@ export async function reqKeygen(
 
 export async function reqKeygenV2(
   endpoint: string,
-  payload: KeygenBodyV2,
+  payload: KeygenRequestBodyV2,
   authToken: string,
 ) {
   const resp: OkoApiResponse<SignInResponseV2> = await makePostRequest(

--- a/crypto/teddsa/api_lib/src/index.ts
+++ b/crypto/teddsa/api_lib/src/index.ts
@@ -1,5 +1,5 @@
 import type {
-  KeygenEd25519Body,
+  KeygenEd25519RequestBody,
   SignEd25519Round1Body,
   SignEd25519Round1Response,
   SignEd25519Round2Body,
@@ -118,7 +118,7 @@ async function makePostRequest<T, R>(
 
 export async function reqKeygenEd25519(
   endpoint: string,
-  payload: KeygenEd25519Body,
+  payload: KeygenEd25519RequestBody,
   authToken: string,
 ) {
   const resp: OkoApiResponse<SignInResponseV2> = await makePostRequest(

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/user_v2.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/user_v2.ts
@@ -161,6 +161,7 @@ export async function handleNewUserV2(
   const reqKeygenV2Res = await reqKeygenV2(
     TSS_V2_ENDPOINT,
     {
+      auth_type: authType,
       keygen_2_secp256k1: {
         public_key: secp256k1Keygen1.public_key.toHex(),
         private_share: secp256k1Keygen2.tss_private_share.toHex(),
@@ -569,6 +570,7 @@ export async function handleExistingUserNeedsEd25519Keygen(
   const reqKeygenEd25519Res = await reqKeygenEd25519(
     TSS_V2_ENDPOINT,
     {
+      auth_type: authType,
       keygen_2: {
         key_package: serializeKeyPackage(ed25519Keygen2.key_package),
         public_key_package: serializePublicKeyPackage(
@@ -1075,6 +1077,7 @@ export async function handleReshareAndEd25519Keygen(
   const reqKeygenEd25519Res = await reqKeygenEd25519(
     TSS_V2_ENDPOINT,
     {
+      auth_type: authType,
       keygen_2: {
         key_package: serializeKeyPackage(ed25519Keygen2.key_package),
         public_key_package: serializePublicKeyPackage(

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/user_v2.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/user_v2.ts
@@ -39,6 +39,7 @@ import {
   runTeddsaKeygen,
   serializeKeyPackage,
   serializePublicKeyPackage,
+  type TeddsaKeygenOutputBytes,
 } from "@oko-wallet/teddsa-hooks";
 import { reqKeygenEd25519 } from "@oko-wallet/teddsa-api-lib";
 import { reqKeygenV2 } from "@oko-wallet/api-lib";
@@ -83,16 +84,17 @@ export async function handleNewUserV2(
   const { keygen_1: secp256k1Keygen1, keygen_2: secp256k1Keygen2 } =
     secp256k1KeygenRes.data;
 
-  // 2. ed25519 keygen
-  const ed25519KeygenRes = await runTeddsaKeygen();
-  if (ed25519KeygenRes.success === false) {
-    return {
-      success: false,
-      err: { type: "sign_in_request_fail", error: ed25519KeygenRes.err },
-    };
+  // 2. ed25519 keygen and split
+  const ed25519KeygenSplitRes =
+    await runEd25519KeygenAndSplit(keyshareNodeMeta);
+  if (ed25519KeygenSplitRes.success === false) {
+    return { success: false, err: ed25519KeygenSplitRes.err };
   }
-  const { keygen_1: ed25519Keygen1, keygen_2: ed25519Keygen2 } =
-    ed25519KeygenRes.data;
+  const {
+    keygen1: ed25519Keygen1,
+    keygen2: ed25519Keygen2,
+    userKeyShares: ed25519UserKeyShares,
+  } = ed25519KeygenSplitRes.data;
 
   // 3. secp256k1 key share split
   const splitUserKeySharesRes = await splitUserKeyShares(
@@ -106,28 +108,6 @@ export async function handleNewUserV2(
     };
   }
   const secp256k1UserKeyShares = splitUserKeySharesRes.data;
-
-  // 4. ed25519 key share split
-  const ed25519SigningShareRes = extractSigningShare(
-    ed25519Keygen1.key_package,
-  );
-  if (ed25519SigningShareRes.success === false) {
-    return {
-      success: false,
-      err: { type: "sign_in_request_fail", error: ed25519SigningShareRes.err },
-    };
-  }
-  const ed25519SplitRes = await splitTeddsaSigningShare(
-    ed25519SigningShareRes.data,
-    keyshareNodeMeta,
-  );
-  if (ed25519SplitRes.success === false) {
-    return {
-      success: false,
-      err: { type: "sign_in_request_fail", error: ed25519SplitRes.err },
-    };
-  }
-  const ed25519UserKeyShares = ed25519SplitRes.data;
 
   // 5. Send key shares by both curves to ks nodes using V2 API
   const registerKeySharesResults: Result<void, string>[] = await Promise.all(
@@ -303,37 +283,16 @@ export async function handleExistingUserV2(
     };
   }
 
-  // 3. Combine secp256k1 shares (convert hex strings to Point256)
-  const secp256k1SharesByNode: UserKeySharePointByNode[] = [];
-  for (const item of requestSharesRes.data) {
-    const shareHex = item.shares.secp256k1;
-    if (!shareHex) {
-      return {
-        success: false,
-        err: {
-          type: "key_share_combine_fail",
-          error: `secp256k1 share missing from node: ${item.node.name}`,
-        },
-      };
-    }
-    const point256Res = decodeKeyShareStringToPoint256(shareHex);
-    if (point256Res.success === false) {
-      return {
-        success: false,
-        err: {
-          type: "key_share_combine_fail",
-          error: `secp256k1 decode err: ${point256Res.err}`,
-        },
-      };
-    }
-    secp256k1SharesByNode.push({
-      node: item.node,
-      share: point256Res.data,
-    });
+  // 3. Decode and combine secp256k1 shares
+  const secp256k1DecodeRes = await decodeSecp256k1SharesByNode(
+    requestSharesRes.data,
+  );
+  if (!secp256k1DecodeRes.success) {
+    return { success: false, err: secp256k1DecodeRes.err };
   }
 
   const keyshare1Secp256k1Res = await combineUserShares(
-    secp256k1SharesByNode,
+    secp256k1DecodeRes.data,
     keyshareNodeMetaSecp256k1.threshold,
   );
   if (keyshare1Secp256k1Res.success === false) {
@@ -508,40 +467,20 @@ export async function handleExistingUserNeedsEd25519Keygen(
   keyshareNodeMetaEd25519: KeyShareNodeMetaWithNodeStatusInfo,
   authType: AuthType,
 ): Promise<Result<UserSignInResultV2, OAuthSignInError>> {
-  // 1. ed25519 keygen
-  const ed25519KeygenRes = await runTeddsaKeygen();
-  if (ed25519KeygenRes.success === false) {
-    return {
-      success: false,
-      err: { type: "sign_in_request_fail", error: ed25519KeygenRes.err },
-    };
-  }
-  const { keygen_1: ed25519Keygen1, keygen_2: ed25519Keygen2 } =
-    ed25519KeygenRes.data;
-
-  // 2. ed25519 key share split
-  const ed25519SigningShareRes = extractSigningShare(
-    ed25519Keygen1.key_package,
-  );
-  if (ed25519SigningShareRes.success === false) {
-    return {
-      success: false,
-      err: { type: "sign_in_request_fail", error: ed25519SigningShareRes.err },
-    };
-  }
-  const ed25519SplitRes = await splitTeddsaSigningShare(
-    ed25519SigningShareRes.data,
+  // 1. ed25519 keygen and split
+  const ed25519KeygenSplitRes = await runEd25519KeygenAndSplit(
     keyshareNodeMetaEd25519,
   );
-  if (ed25519SplitRes.success === false) {
-    return {
-      success: false,
-      err: { type: "sign_in_request_fail", error: ed25519SplitRes.err },
-    };
+  if (ed25519KeygenSplitRes.success === false) {
+    return { success: false, err: ed25519KeygenSplitRes.err };
   }
-  const ed25519UserKeyShares = ed25519SplitRes.data;
+  const {
+    keygen1: ed25519Keygen1,
+    keygen2: ed25519Keygen2,
+    userKeyShares: ed25519UserKeyShares,
+  } = ed25519KeygenSplitRes.data;
 
-  // 3. Send ed25519 key shares to ks nodes using V2 API
+  // 2. Send ed25519 key shares to ks nodes using V2 API
   const registerEd25519Results: Result<void, string>[] = await Promise.all(
     keyshareNodeMetaEd25519.nodes.map((node, index) =>
       registerKeyShareEd25519V2(
@@ -630,37 +569,16 @@ export async function handleExistingUserNeedsEd25519Keygen(
     };
   }
 
-  // 7. Combine secp256k1 shares (convert hex strings to Point256)
-  const secp256k1SharesByNode: UserKeySharePointByNode[] = [];
-  for (const item of requestSharesRes.data) {
-    const shareHex = item.shares.secp256k1;
-    if (!shareHex) {
-      return {
-        success: false,
-        err: {
-          type: "key_share_combine_fail",
-          error: `secp256k1 share missing from node: ${item.node.name}`,
-        },
-      };
-    }
-    const point256Res = decodeKeyShareStringToPoint256(shareHex);
-    if (point256Res.success === false) {
-      return {
-        success: false,
-        err: {
-          type: "key_share_combine_fail",
-          error: `secp256k1 decode err: ${point256Res.err}`,
-        },
-      };
-    }
-    secp256k1SharesByNode.push({
-      node: item.node,
-      share: point256Res.data,
-    });
+  // 6. Decode and combine secp256k1 shares
+  const secp256k1DecodeRes = await decodeSecp256k1SharesByNode(
+    requestSharesRes.data,
+  );
+  if (!secp256k1DecodeRes.success) {
+    return { success: false, err: secp256k1DecodeRes.err };
   }
 
   const keyshare1Secp256k1Res = await combineUserShares(
-    secp256k1SharesByNode,
+    secp256k1DecodeRes.data,
     keyshareNodeMetaSecp256k1.threshold,
   );
   if (keyshare1Secp256k1Res.success === false) {
@@ -673,7 +591,7 @@ export async function handleExistingUserNeedsEd25519Keygen(
     };
   }
 
-  // 8. Convert ed25519 keygen1 to hex format for storage
+  // 7. Convert ed25519 keygen1 to hex format for storage
   const keyPackageEd25519Hex = teddsaKeygenToHex(ed25519Keygen1);
 
   return {
@@ -870,51 +788,20 @@ export async function handleReshareAndEd25519Keygen(
     };
   }
 
-  // 2. ed25519 keygen (new)
-  const ed25519KeygenRes = await runTeddsaKeygen();
-  if (ed25519KeygenRes.success === false) {
-    return {
-      success: false,
-      err: { type: "sign_in_request_fail", error: ed25519KeygenRes.err },
-    };
-  }
-  const { keygen_1: ed25519Keygen1, keygen_2: ed25519Keygen2 } =
-    ed25519KeygenRes.data;
-
-  // 3. ed25519 key share split
-  const ed25519SigningShareRes = extractSigningShare(
-    ed25519Keygen1.key_package,
-  );
-  if (ed25519SigningShareRes.success === false) {
-    return {
-      success: false,
-      err: { type: "sign_in_request_fail", error: ed25519SigningShareRes.err },
-    };
-  }
-  const ed25519SplitRes = await splitTeddsaSigningShare(
-    ed25519SigningShareRes.data,
+  // 2. ed25519 keygen and split
+  const ed25519KeygenSplitRes = await runEd25519KeygenAndSplit(
     keyshareNodeMetaEd25519,
   );
-  if (ed25519SplitRes.success === false) {
-    return {
-      success: false,
-      err: { type: "sign_in_request_fail", error: ed25519SplitRes.err },
-    };
+  if (ed25519KeygenSplitRes.success === false) {
+    return { success: false, err: ed25519KeygenSplitRes.err };
   }
-  const ed25519UserKeyShares = ed25519SplitRes.data;
+  const {
+    keygen1: ed25519Keygen1,
+    keygen2: ed25519Keygen2,
+    userKeyShares: ed25519UserKeyShares,
+  } = ed25519KeygenSplitRes.data;
 
-  // 4. Request secp256k1 shares from ACTIVE nodes
-  const requestSharesRes = await requestKeySharesV2(
-    idToken,
-    activeNodes,
-    keyshareNodeMetaSecp256k1.threshold,
-    authType,
-    {
-      secp256k1: undefined, // Will be filled after sign-in
-    },
-  );
-
-  // We need to sign in first to get the public key
+  // 3. Sign in to get the public key
   const signInRes = await makeAuthorizedOkoApiRequest<any, SignInResponseV2>(
     "user/signin",
     idToken,
@@ -963,31 +850,25 @@ export async function handleReshareAndEd25519Keygen(
     };
   }
 
-  // 6. secp256k1 expand
-  const secp256k1SharesByNode: UserKeySharePointByNode[] = [];
-  for (const item of requestSecp256k1SharesRes.data) {
-    const shareHex = item.shares.secp256k1;
-    if (!shareHex) {
-      continue;
-    }
-    const point256Res = decodeKeyShareStringToPoint256(shareHex);
-    if (!point256Res.success) {
-      return {
-        success: false,
-        err: {
-          type: "reshare_fail",
-          error: `secp256k1 decode err: ${point256Res.err}`,
-        },
-      };
-    }
-    secp256k1SharesByNode.push({
-      node: item.node,
-      share: point256Res.data,
-    });
+  // 5. Decode secp256k1 shares (filter out items without shares for reshare case)
+  const itemsWithSecp256k1 = requestSecp256k1SharesRes.data.filter(
+    (item) => item.shares.secp256k1,
+  );
+  const secp256k1DecodeRes =
+    await decodeSecp256k1SharesByNode(itemsWithSecp256k1);
+  if (!secp256k1DecodeRes.success) {
+    return {
+      success: false,
+      err: {
+        type: "reshare_fail",
+        error: secp256k1DecodeRes.err.error,
+      },
+    };
   }
 
+  // 6. Expand secp256k1 shares to additional nodes
   const secp256k1ExpandRes = await runExpandShares(
-    secp256k1SharesByNode,
+    secp256k1DecodeRes.data,
     additionalNodes,
     keyshareNodeMetaSecp256k1.threshold,
   );
@@ -1167,4 +1048,110 @@ async function saveReferralV2(
   if (!apiResponse.success) {
     throw new Error(`Save referral V2 API error: ${apiResponse.msg}`);
   }
+}
+
+/**
+ * Decode secp256k1 shares from hex strings to Point256 format.
+ * Used by multiple handlers that need to process shares from KS nodes.
+ */
+async function decodeSecp256k1SharesByNode(
+  sharesData: Array<{
+    node: { name: string; endpoint: string };
+    shares: { secp256k1?: string };
+  }>,
+): Promise<
+  Result<
+    UserKeySharePointByNode[],
+    { type: "key_share_combine_fail"; error: string }
+  >
+> {
+  const sharesByNode: UserKeySharePointByNode[] = [];
+
+  for (const item of sharesData) {
+    const shareHex = item.shares.secp256k1;
+    if (!shareHex) {
+      return {
+        success: false,
+        err: {
+          type: "key_share_combine_fail",
+          error: `secp256k1 share missing from node: ${item.node.name}`,
+        },
+      };
+    }
+    const point256Res = decodeKeyShareStringToPoint256(shareHex);
+    if (point256Res.success === false) {
+      return {
+        success: false,
+        err: {
+          type: "key_share_combine_fail",
+          error: `secp256k1 decode err: ${point256Res.err}`,
+        },
+      };
+    }
+    sharesByNode.push({
+      node: item.node,
+      share: point256Res.data,
+    });
+  }
+
+  return { success: true, data: sharesByNode };
+}
+
+interface Ed25519KeygenSplitResult {
+  keygen1: TeddsaKeygenOutputBytes;
+  keygen2: TeddsaKeygenOutputBytes;
+  userKeyShares: TeddsaKeyShareByNode[];
+}
+
+/**
+ * Run ed25519 keygen and split the signing share for distribution to KS nodes.
+ * Used by handlers that need to create new ed25519 wallets.
+ */
+async function runEd25519KeygenAndSplit(
+  keyshareNodeMeta: KeyShareNodeMetaWithNodeStatusInfo,
+): Promise<
+  Result<
+    Ed25519KeygenSplitResult,
+    { type: "sign_in_request_fail"; error: string }
+  >
+> {
+  // 1. ed25519 keygen
+  const ed25519KeygenRes = await runTeddsaKeygen();
+  if (ed25519KeygenRes.success === false) {
+    return {
+      success: false,
+      err: { type: "sign_in_request_fail", error: ed25519KeygenRes.err },
+    };
+  }
+  const { keygen_1: keygen1, keygen_2: keygen2 } = ed25519KeygenRes.data;
+
+  // 2. Extract signing share from key package
+  const signingShareRes = extractSigningShare(keygen1.key_package);
+  if (signingShareRes.success === false) {
+    return {
+      success: false,
+      err: { type: "sign_in_request_fail", error: signingShareRes.err },
+    };
+  }
+
+  // 3. Split signing share for distribution
+  const splitRes = await splitTeddsaSigningShare(
+    signingShareRes.data,
+    keyshareNodeMeta,
+  );
+  if (splitRes.success === false) {
+    return {
+      success: false,
+      err: { type: "sign_in_request_fail", error: splitRes.err },
+    };
+  }
+
+  return {
+    success: true,
+    data: {
+      keygen1,
+      keygen2,
+      userKeyShares: splitRes.data,
+    },
+  };
 }

--- a/internals/ci/src/cmds/deploy.ts
+++ b/internals/ci/src/cmds/deploy.ts
@@ -30,6 +30,9 @@ const APP_CONFIGS = {
   "oko-sandbox-evm": {
     path: path.join(paths.root, "sandbox/sandbox_evm"),
   },
+  "oko-sandbox-sol": {
+    path: path.join(paths.root, "sandbox/sandbox_sol"),
+  },
 };
 
 function listDeployableApps(): void {

--- a/internals/docker/oko_api_server.Dockerfile
+++ b/internals/docker/oko_api_server.Dockerfile
@@ -71,16 +71,16 @@ RUN yarn workspaces focus @oko-wallet/tecdsa-interface
 WORKDIR /home/node/oko/crypto/tecdsa/tecdsa_interface
 RUN yarn run build
 
-# Build teddsa-interface
-WORKDIR /home/node/oko
-RUN yarn workspaces focus @oko-wallet/teddsa-interface
-WORKDIR /home/node/oko/crypto/teddsa/teddsa_interface
-RUN yarn run build
-
-# Build oko-types (depends on stdlib-js, tecdsa-interface, teddsa-interface)
+# Build oko-types (depends on stdlib-js, bytes, tecdsa-interface)
 WORKDIR /home/node/oko
 RUN yarn workspaces focus @oko-wallet/oko-types
 WORKDIR /home/node/oko/common/oko_types
+RUN yarn run build
+
+# Build teddsa-interface (depends on bytes, oko-types/teddsa)
+WORKDIR /home/node/oko
+RUN yarn workspaces focus @oko-wallet/teddsa-interface
+WORKDIR /home/node/oko/crypto/teddsa/teddsa_interface
 RUN yarn run build
 
 # Install dependencies for crypto-js

--- a/sandbox/sandbox_sol/src/hooks/use_oko_sol.ts
+++ b/sandbox/sandbox_sol/src/hooks/use_oko_sol.ts
@@ -23,7 +23,9 @@ export function useOkoSol() {
 
   // Initialize SDK
   useEffect(() => {
-    if (isInitialized || isInitializing) return;
+    if (isInitialized || isInitializing) {
+      return;
+    }
 
     const initSdk = async () => {
       setIsInitializing(true);
@@ -88,7 +90,9 @@ export function useOkoSol() {
   ]);
 
   useEffect(() => {
-    if (!okoSolWallet) return;
+    if (!okoSolWallet) {
+      return;
+    }
 
     const handleAccountChanged = (pk: PublicKey | null) => {
       const pubkeyStr = pk?.toBase58() ?? null;
@@ -148,7 +152,9 @@ export function useOkoSol() {
 
   // Disconnect wallet
   const disconnect = useCallback(async () => {
-    if (!okoSolWallet) return;
+    if (!okoSolWallet) {
+      return;
+    }
 
     try {
       await okoSolWallet.disconnect();

--- a/sandbox/sandbox_sol/src/hooks/use_oko_sol.ts
+++ b/sandbox/sandbox_sol/src/hooks/use_oko_sol.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import type { PublicKey } from "@solana/web3.js";
 import { OkoSolWallet, registerOkoWallet } from "@oko-wallet/oko-sdk-sol";
 import { useSdkStore } from "@/store/sdk";
 
@@ -63,9 +64,10 @@ export function useOkoSol() {
           await solWallet.okoWallet.getPublicKeyEd25519();
         if (existingEd25519Pubkey) {
           await solWallet.connect();
-          const pk = solWallet.publicKey?.toBase58() ?? null;
-          setConnected(true, pk);
-          console.log("[sandbox_sol] Reconnected:", pk);
+          console.log(
+            "[sandbox_sol] Reconnected:",
+            solWallet.publicKey?.toBase58(),
+          );
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -83,8 +85,37 @@ export function useOkoSol() {
     setOkoWallet,
     setOkoSolWallet,
     setInitialized,
-    setConnected,
   ]);
+
+  useEffect(() => {
+    if (!okoSolWallet) return;
+
+    const handleAccountChanged = (pk: PublicKey | null) => {
+      const pubkeyStr = pk?.toBase58() ?? null;
+      setConnected(!!pk, pubkeyStr);
+      console.log("[sandbox_sol] accountChanged event:", pubkeyStr);
+    };
+
+    const handleConnect = (pk: PublicKey) => {
+      setConnected(true, pk.toBase58());
+      console.log("[sandbox_sol] connect event:", pk.toBase58());
+    };
+
+    const handleDisconnect = () => {
+      setConnected(false, null);
+      console.log("[sandbox_sol] disconnect event");
+    };
+
+    okoSolWallet.on("accountChanged", handleAccountChanged);
+    okoSolWallet.on("connect", handleConnect);
+    okoSolWallet.on("disconnect", handleDisconnect);
+
+    return () => {
+      okoSolWallet.off("accountChanged", handleAccountChanged);
+      okoSolWallet.off("connect", handleConnect);
+      okoSolWallet.off("disconnect", handleDisconnect);
+    };
+  }, [okoSolWallet, setConnected]);
 
   const connect = useCallback(async () => {
     if (!okoSolWallet) {
@@ -104,15 +135,16 @@ export function useOkoSol() {
 
       // connect() internally handles Ed25519 key creation if needed
       await okoSolWallet.connect();
-      const pk = okoSolWallet.publicKey?.toBase58() ?? null;
-      setConnected(true, pk);
-      console.log("[sandbox_sol] Connected:", pk);
+      console.log(
+        "[sandbox_sol] Connected:",
+        okoSolWallet.publicKey?.toBase58(),
+      );
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setError(message);
       console.error("[sandbox_sol] Failed to connect:", message);
     }
-  }, [okoSolWallet, setConnected]);
+  }, [okoSolWallet]);
 
   // Disconnect wallet
   const disconnect = useCallback(async () => {
@@ -120,14 +152,13 @@ export function useOkoSol() {
 
     try {
       await okoSolWallet.disconnect();
-      setConnected(false, null);
       console.log("[sandbox_sol] Disconnected");
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setError(message);
       console.error("[sandbox_sol] Failed to disconnect:", message);
     }
-  }, [okoSolWallet, setConnected]);
+  }, [okoSolWallet]);
 
   return {
     okoWallet,

--- a/sandbox/sandbox_sol/src/lib/connection.ts
+++ b/sandbox/sandbox_sol/src/lib/connection.ts
@@ -1,6 +1,8 @@
 import { Connection } from "@solana/web3.js";
 
+const DEFAULT_RPC_URL = "https://api.devnet.solana.com";
+
 export const DEVNET_CONNECTION = new Connection(
-  "https://api.devnet.solana.com",
+  process.env.NEXT_PUBLIC_SOLANA_RPC_URL || DEFAULT_RPC_URL,
   "confirmed",
 );

--- a/sdk/oko_sdk_core/src/methods/sign_in/index.ts
+++ b/sdk/oko_sdk_core/src/methods/sign_in/index.ts
@@ -33,7 +33,6 @@ export async function signIn(this: OkoWalletInterface, type: SignInType) {
     throw new Error(`Sign in error, err: ${err}`);
   }
 
-  // @TODO: required for ed25519 support
   const walletInfo = await this.getWalletInfo();
 
   if (!walletInfo) {


### PR DESCRIPTION
## Summary
- Activate Sol SDK initialization in demo_web
- Add Solana address display to address widget
- Activate Solana offchain/onchain sign widgets

## Changes
### 1. Sol SDK Initialization (`sdk.ts`, `use_oko.ts`)
- Uncomment `@oko-wallet/oko-sdk-sol` import and types
- Add `oko_sol` state to SDKState interface
- Implement `initOkoSol()` function
- Add `initOkoSol` call in `useInitOko` hook

### 2. Address Widget (`wallet.ts`, `address_row.tsx`, `address_widget.tsx`)
- Add `solanaAddress` state and fetch logic in `useAddresses` hook
- Add "solana" chain type with `chainConfig` refactoring
- Add Solana row with `SolanaIcon`

### 3. Solana Sign Widgets (`preview_panel.tsx`, `solana_*_sign_widget.tsx`)
- Uncomment `SolanaOffchainSignWidget` (Ed25519 message signing)
- Uncomment `SolanaOnchainSignWidget` (Legacy/V0 transaction signing)
- Add `isSolLazyInitialized` check and widget rendering

## Test plan
- [ ] Login to demo_web
- [ ] Verify Solana address is displayed in address widget
- [ ] Test Solana offchain sign (message signing)
- [ ] Test Solana onchain sign (devnet transaction)
- [ ] Verify signature uses FROST (Ed25519 MPC) via console logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)