### PR TITLE
oko_attached: fix evm tx fee not set when priority fee is zero

### DIFF
--- a/embed/oko_attached/src/components/modal_variants/eth/tx_sig/hooks/use_tx_sig_modal.tsx
+++ b/embed/oko_attached/src/components/modal_variants/eth/tx_sig/hooks/use_tx_sig_modal.tsx
@@ -218,7 +218,10 @@ export function useTxSigModal(args: UseEthereumSigModalArgs) {
 
     if (feeData !== undefined) {
       if (feeData.type === "eip1559") {
-        if (!feeData.maxFeePerGas || !feeData.maxPriorityFeePerGas) {
+        if (
+          feeData.maxFeePerGas === undefined ||
+          feeData.maxPriorityFeePerGas === undefined
+        ) {
           return;
         }
 


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Some chains like Arbitrum have priority fee fields but don't actually use them at the chain level. In these cases, `eth_feeHistory` or priority fee related RPC methods may return 0.

Since `BigInt(0)` is falsy in JavaScript, the existing `!feeData.maxPriorityFeePerGas` check evaluated to `true`, causing fee fields to not be set on the transaction.

For example, when fee data wasn't set on Arbitrum, the raw tx was constructed without fee fields:

```json
{
  "to": "0x66a503a1060ab3f2b1aaabed613fe30babbc1bde",
  "data": "0xc7c7f5b30000000000000000000...",
  "value": "0x217b371a6f87",
  "gas": "0x3f665"
}
```

Changed to explicit `undefined` check so that 0 is treated as a valid value.

> I cleared my machine for storage and removed my oko setup, so it would be great if someone
   else could test this.

## Links (Issue References, etc, if there's any)

[oko canny](https://oko-wallet.canny.io/admin/board/bug-reports/p/error-message-using-bidge-from-eth-arb-to-civitia-init-using-oko-wallet)