### PR TITLE
github: add deployment environment to deploy workflows

### DIFF
--- a/.github/workflows/deploy_oko_apps.yml
+++ b/.github/workflows/deploy_oko_apps.yml
@@ -26,6 +26,8 @@ jobs:
   publish:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
+    environment:
+      name: ${{ contains(inputs.git_tag, 'release/') && 'Production' || 'Preview' }}
     steps:
       - name: Checkout self repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy_oko_attached.yml
+++ b/.github/workflows/deploy_oko_attached.yml
@@ -15,6 +15,8 @@ jobs:
   publish:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
+    environment:
+      name: ${{ contains(inputs.git_tag, 'release/') && 'Production' || 'Preview' }}
     steps:
       - name: Checkout self repository
         uses: actions/checkout@v4


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [x] I’ve read `CONTRIBUTING.md` and followed the guidelines.

## Summary

<img width="626" height="1744" alt="image" src="https://github.com/user-attachments/assets/ceadc8e3-b151-4e73-8170-6a94bcdcd590" />

Add GitHub deployment environment (`Production` / `Preview`) to Vercel deploy workflows so deployment status badges appear on the repo

## Links (Issue References, etc, if there's any)

<!-- List related issues or PRs (e.g., Closes #123; Related #456). -->
