### PR TITLE
oko_attached: show email by default in EVM/Cosmos tx signing modals

### DIFF
--- a/embed/oko_attached/src/components/modal_variants/common/metadata_content/metadata_content.tsx
+++ b/embed/oko_attached/src/components/modal_variants/common/metadata_content/metadata_content.tsx
@@ -13,12 +13,14 @@ interface MakeSignatureModalMetadataContentProps {
   origin: string;
   chainInfo: ChainInfoForAttachedModal;
   signer: string;
+  initialViewType?: "View Address" | "Login Info" | null;
 }
 
 export const MetadataContent: FC<MakeSignatureModalMetadataContentProps> = ({
   origin,
   chainInfo,
   signer,
+  initialViewType = null,
 }) => {
   const faviconUrl = getFaviconUrl(origin);
   const isMobile = useMobileMode();
@@ -63,7 +65,7 @@ export const MetadataContent: FC<MakeSignatureModalMetadataContentProps> = ({
         <SignerAddressOrEmail
           signer={signer}
           origin={origin}
-          initialViewType={null}
+          initialViewType={initialViewType}
         />
       </div>
     </div>

--- a/embed/oko_attached/src/components/modal_variants/cosmos/tx_sig/cosmos_tx_signature_content.tsx
+++ b/embed/oko_attached/src/components/modal_variants/cosmos/tx_sig/cosmos_tx_signature_content.tsx
@@ -23,6 +23,7 @@ export const CosmosTxSignatureContent: FC<CosmosTxSignatureContentProps> = ({
         origin={payload.origin}
         chainInfo={payload.chain_info}
         signer={payload.signer}
+        initialViewType="Login Info"
       />
       <Spacing height={28} />
       <CosmosTxSummary

--- a/embed/oko_attached/src/components/modal_variants/eth/tx_sig/ethereum_tx_signature_content.tsx
+++ b/embed/oko_attached/src/components/modal_variants/eth/tx_sig/ethereum_tx_signature_content.tsx
@@ -20,6 +20,7 @@ export const EthereumTxSignatureContent: FC<
         origin={payload.origin}
         chainInfo={payload.chain_info}
         signer={payload.signer}
+        initialViewType="Login Info"
       />
       <Spacing height={28} />
       <EthereumTxSummary


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

EVM and Cosmos tx signing modals were defaulting to showing the wallet address, while the SVM tx modal correctly showed the user's email (Login Info) by default. This inconsistency was caused by `MetadataContent` hardcoding `initialViewType={null}` when the SVM modal bypassed it entirely.

Added `initialViewType` prop to `MetadataContent` and passed `"Login Info"` from EVM/Cosmos tx signature modals to match SVM behavior.

## Links (Issue References, etc, if there's any)

OKO-775