### PR TITLE
ci: replace setup-node built-in cache with actions/cache for Yarn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: "yarn"
+
+      - name: Get Yarn cache directory
+        id: yarn-cache
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Yarn
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/deploy_oko_apps.yml
+++ b/.github/workflows/deploy_oko_apps.yml
@@ -36,7 +36,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: "yarn"
+
+      - name: Get Yarn cache directory
+        id: yarn-cache
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Yarn
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
 
       - name: Check Node version
         run: node -v

--- a/.github/workflows/deploy_oko_attached.yml
+++ b/.github/workflows/deploy_oko_attached.yml
@@ -31,7 +31,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: "yarn"
+
+      - name: Get Yarn cache directory
+        id: yarn-cache
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Yarn
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
 
       - name: Check Node version
         run: node -v

--- a/.github/workflows/publish_node_pkgs.yml
+++ b/.github/workflows/publish_node_pkgs.yml
@@ -15,16 +15,25 @@ jobs:
           ref: ${{ inputs.git_tag }}
           token: ${{ secrets.GH_PAT }}
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22"
 
-      - name: Check Node version
-        run: node -v
-      
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Get Yarn cache directory
+        id: yarn-cache
+        run: echo "dir=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Yarn
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
 
       - name: Yarn version
         run: yarn -v


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Replace `actions/setup-node`'s built-in `cache: "yarn"` with `actions/cache@v4` across all workflows. The built-in cache only supports exact key matching, causing frequent cache misses when `yarn.lock` hash differs between tags and branches. The new setup uses `restore-keys` prefix matching for better fallback behavior. Also adds missing Yarn cache to `publish_node_pkgs.yml`.

## Links (Issue References, etc, if there's any)

OKO-776