### PR TITLE
OKO-759

### DIFF
--- a/apps/user_dashboard/src/components/dashboard_header/dashboard_header.module.scss
+++ b/apps/user_dashboard/src/components/dashboard_header/dashboard_header.module.scss
@@ -44,9 +44,13 @@
 }
 
 .authProviderIcon {
-  display: flex;
+  display: none;
   align-items: center;
   flex-shrink: 0;
+
+  @media (min-width: $desktop_min_width) {
+    display: flex;
+  }
 }
 
 .accountEmail {
@@ -55,6 +59,35 @@
 
   @media (min-width: $desktop_min_width) {
     display: block;
+  }
+}
+
+// Mobile menu trigger: auth icon in circle
+.mobileMenuTrigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--bg-tertiary);
+  border-radius: 50%;
+  padding: 4px;
+  cursor: pointer;
+
+  @media (min-width: $desktop_min_width) {
+    display: none;
+  }
+}
+
+// Dropdown open state: change mobile trigger bg
+:global([aria-expanded="true"]) > .mobileMenuTrigger {
+  background-color: var(--bg-quaternary);
+}
+
+// Desktop menu trigger: dots icon
+.desktopMenuTrigger {
+  display: none;
+
+  @media (min-width: $desktop_min_width) {
+    display: flex;
   }
 }
 
@@ -81,4 +114,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  @media (max-width: ($desktop_min_width - 1)) {
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
 }

--- a/apps/user_dashboard/src/components/dashboard_header/dashboard_header.module.scss
+++ b/apps/user_dashboard/src/components/dashboard_header/dashboard_header.module.scss
@@ -15,6 +15,12 @@
   }
 }
 
+.leftSection {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .logo {
   flex-shrink: 0;
   cursor: pointer;
@@ -29,7 +35,9 @@
 .menuIconWrapper {
   display: flex;
   align-items: center;
-  height: 100%;
+  justify-content: center;
+  padding: 8px;
+  cursor: pointer;
 
   @media (min-width: $desktop_min_width) {
     display: none;
@@ -62,15 +70,21 @@
   }
 }
 
-// Mobile menu trigger: auth icon in circle
+// Mobile menu trigger: auth icon in circle (32px visual, 40px touch area)
 .mobileMenuTrigger {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--bg-tertiary);
-  border-radius: 50%;
+  width: 32px;
+  height: 32px;
   padding: 4px;
+  box-sizing: content-box;
+  background-color: var(--bg-tertiary);
+  background-clip: content-box;
+  border-radius: 50%;
+  overflow: hidden;
   cursor: pointer;
+  flex-shrink: 0;
 
   @media (min-width: $desktop_min_width) {
     display: none;

--- a/apps/user_dashboard/src/components/dashboard_header/dashboard_header.tsx
+++ b/apps/user_dashboard/src/components/dashboard_header/dashboard_header.tsx
@@ -8,6 +8,7 @@ import { ExternalLinkOutlinedIcon } from "@oko-wallet/oko-common-ui/icons/extern
 import { GithubIcon } from "@oko-wallet/oko-common-ui/icons/github_icon";
 import { GoogleIcon } from "@oko-wallet/oko-common-ui/icons/google_icon";
 import { LogoutIcon } from "@oko-wallet/oko-common-ui/icons/logout";
+import { MailboxIcon } from "@oko-wallet/oko-common-ui/icons/mailbox";
 import { MenuIcon } from "@oko-wallet/oko-common-ui/icons/menu";
 import { TelegramIcon } from "@oko-wallet/oko-common-ui/icons/telegram_icon";
 import { XCloseIcon } from "@oko-wallet/oko-common-ui/icons/x_close";
@@ -44,6 +45,25 @@ function getAuthProviderIcon(authType: AuthType | null, size = 16): ReactNode {
       return <XIcon size={size} />;
     case "github":
       return <GithubIcon size={size} />;
+    default:
+      return null;
+  }
+}
+
+function getMobileTriggerIcon(authType: AuthType | null): ReactNode {
+  switch (authType) {
+    case "google":
+      return <GoogleIcon width={24} height={24} />;
+    case "discord":
+      return <DiscordIcon size={20} />;
+    case "telegram":
+      return <TelegramIcon size={24} />;
+    case "x":
+      return <XIcon size={24} />;
+    case "github":
+      return <GithubIcon size={24} />;
+    case "auth0":
+      return <MailboxIcon size={20} color="var(--fg-tertiary)" />;
     default:
       return null;
   }
@@ -129,14 +149,23 @@ export const DashboardHeader: FC<{
 
   return (
     <div className={styles.wrapper} style={{ position }}>
-      <img
-        src={logoVariant === "white" ? OKO_LOGO_WHITE_URL : OKO_LOGO_URL}
-        alt="Oko"
-        width={72}
-        height={28}
-        className={styles.logo}
-        onClick={() => router.push(paths.home)}
-      />
+      <div className={styles.leftSection}>
+        <span className={styles.menuIconWrapper} onClick={toggleLeftBarOpen}>
+          {isLeftBarOpen ? (
+            <XCloseIcon color="var(--fg-primary)" size={24} />
+          ) : (
+            <MenuIcon color="var(--fg-primary)" size={24} />
+          )}
+        </span>
+        <img
+          src={logoVariant === "white" ? OKO_LOGO_WHITE_URL : OKO_LOGO_URL}
+          alt="Oko"
+          width={72}
+          height={28}
+          className={styles.logo}
+          onClick={() => router.push(paths.home)}
+        />
+      </div>
 
       <div className={styles.rightSection}>
         {isSignedIn && (
@@ -158,11 +187,9 @@ export const DashboardHeader: FC<{
               placement="bottom-end"
               TriggerComponent={
                 <>
-                  {authType !== "auth0" && (
-                    <span className={styles.mobileMenuTrigger}>
-                      {getAuthProviderIcon(authType, 24)}
-                    </span>
-                  )}
+                  <span className={styles.mobileMenuTrigger}>
+                    {getMobileTriggerIcon(authType)}
+                  </span>
                   <span className={styles.desktopMenuTrigger}>
                     <IconButton
                       hierarchy="tertiary"
@@ -257,14 +284,6 @@ export const DashboardHeader: FC<{
             />
           </div>
         )}
-
-        <span className={styles.menuIconWrapper} onClick={toggleLeftBarOpen}>
-          {isLeftBarOpen ? (
-            <XCloseIcon color="var(--fg-primary)" size={24} />
-          ) : (
-            <MenuIcon color="var(--fg-primary)" size={24} />
-          )}
-        </span>
       </div>
     </div>
   );

--- a/apps/user_dashboard/src/components/dashboard_header/dashboard_header.tsx
+++ b/apps/user_dashboard/src/components/dashboard_header/dashboard_header.tsx
@@ -157,11 +157,20 @@ export const DashboardHeader: FC<{
             <AnchoredMenu
               placement="bottom-end"
               TriggerComponent={
-                <IconButton
-                  hierarchy="tertiary"
-                  size="sm"
-                  icon={<DotsHorizontalIcon size={20} />}
-                />
+                <>
+                  {authType !== "auth0" && (
+                    <span className={styles.mobileMenuTrigger}>
+                      {getAuthProviderIcon(authType, 24)}
+                    </span>
+                  )}
+                  <span className={styles.desktopMenuTrigger}>
+                    <IconButton
+                      hierarchy="tertiary"
+                      size="sm"
+                      icon={<DotsHorizontalIcon size={20} />}
+                    />
+                  </span>
+                </>
               }
               HeaderComponent={
                 <div className={styles.menuHeader}>

--- a/apps/user_dashboard/src/components/left_bar/left_bar.module.scss
+++ b/apps/user_dashboard/src/components/left_bar/left_bar.module.scss
@@ -39,7 +39,7 @@ $header_height: 64px;
       width: 100vw;
       height: 100%;
       padding: 0;
-      z-index: 20;
+      z-index: 1000;
     }
   }
 

--- a/apps/user_dashboard/src/components/left_bar/left_bar.module.scss
+++ b/apps/user_dashboard/src/components/left_bar/left_bar.module.scss
@@ -26,7 +26,7 @@ $header_height: 64px;
   height: 100%;
   background-color: var(--bg-overlay);
   opacity: 0.3;
-  z-index: 0;
+  z-index: 10;
 }
 
 @media (max-width: ($desktop_min_width - 1)) {
@@ -34,8 +34,12 @@ $header_height: 64px;
     &.isOpen {
       display: flex;
       position: fixed;
+      top: 0;
       left: 0;
-      height: calc(100% - $header_height);
+      width: 100vw;
+      height: 100%;
+      padding: 0;
+      z-index: 20;
     }
   }
 
@@ -44,6 +48,57 @@ $header_height: 64px;
       display: block;
     }
   }
+}
+
+.header {
+  display: none;
+
+  @media (max-width: ($desktop_min_width - 1)) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: $header_height;
+    padding: 0 16px;
+    flex-shrink: 0;
+  }
+}
+
+.closeButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.mainMenu {
+  flex: 1;
+  padding: 12px 16px 0;
+
+  @media (min-width: $desktop_min_width) {
+    padding: 0;
+  }
+}
+
+.footer {
+  display: none;
+
+  @media (max-width: ($desktop_min_width - 1)) {
+    display: flex;
+    flex-direction: column;
+    padding: 0 16px 24px;
+  }
+}
+
+.footerItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  text-decoration: none;
+  color: inherit;
 }
 
 .icon {

--- a/apps/user_dashboard/src/components/left_bar/left_bar.tsx
+++ b/apps/user_dashboard/src/components/left_bar/left_bar.tsx
@@ -1,18 +1,33 @@
 "use client";
 
+import { ExternalLinkOutlinedIcon } from "@oko-wallet/oko-common-ui/icons/external_link_outlined";
+import { XCloseIcon } from "@oko-wallet/oko-common-ui/icons/x_close";
 import { MenuItem } from "@oko-wallet/oko-common-ui/menu";
+import { Typography } from "@oko-wallet/oko-common-ui/typography";
 import cn from "classnames";
 import { usePathname } from "next/navigation";
 import type { FC } from "react";
 
 import { navigationItems } from "./constant";
 import styles from "./left_bar.module.scss";
+import {
+  OKO_FEATURE_REQUEST_ENDPOINT,
+  OKO_GET_SUPPORT_ENDPOINT,
+} from "@oko-wallet-user-dashboard/fetch";
 import { useViewState } from "@oko-wallet-user-dashboard/state/view";
+
+const OKO_LOGO_URL =
+  "https://oko-wallet.s3.ap-northeast-2.amazonaws.com/icons/oko_logo.png";
 
 export const LeftBar: FC = () => {
   const isLeftBarOpen = useViewState((state) => state.isLeftBarOpen);
   const toggleLeftBarOpen = useViewState((state) => state.toggleLeftBarOpen);
+  const setLeftBarOpen = useViewState((state) => state.setLeftBarOpen);
   const pathname = usePathname();
+
+  const handleClose = () => {
+    setLeftBarOpen(false);
+  };
 
   return (
     <>
@@ -22,6 +37,17 @@ export const LeftBar: FC = () => {
       />
 
       <div className={cn(styles.wrapper, { [styles.isOpen]: isLeftBarOpen })}>
+        <div className={styles.header}>
+          <img src={OKO_LOGO_URL} alt="Oko" width={72} height={28} />
+          <button
+            type="button"
+            className={styles.closeButton}
+            onClick={handleClose}
+          >
+            <XCloseIcon size={24} color="var(--fg-primary)" />
+          </button>
+        </div>
+
         <ul className={styles.mainMenu}>
           {navigationItems.map((item) => (
             <MenuItem
@@ -30,9 +56,35 @@ export const LeftBar: FC = () => {
               label={item.label}
               Icon={item.icon}
               active={pathname === item.href}
+              onClick={handleClose}
             />
           ))}
         </ul>
+
+        <div className={styles.footer}>
+          <a
+            href={OKO_FEATURE_REQUEST_ENDPOINT}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.footerItem}
+          >
+            <Typography size="sm" weight="semibold" color="secondary">
+              Feature Request
+            </Typography>
+            <ExternalLinkOutlinedIcon color="var(--fg-quaternary)" />
+          </a>
+          <a
+            href={OKO_GET_SUPPORT_ENDPOINT}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.footerItem}
+          >
+            <Typography size="sm" weight="semibold" color="secondary">
+              Get Support
+            </Typography>
+            <ExternalLinkOutlinedIcon color="var(--fg-quaternary)" />
+          </a>
+        </div>
       </div>
     </>
   );

--- a/apps/user_dashboard/src/state/view.ts
+++ b/apps/user_dashboard/src/state/view.ts
@@ -6,11 +6,15 @@ interface ViewState {
 
 interface ViewAction {
   toggleLeftBarOpen: () => void;
+  setLeftBarOpen: (value: boolean) => void;
 }
 
 export const useViewState = create<ViewState & ViewAction>((set) => ({
   isLeftBarOpen: false,
   toggleLeftBarOpen: () => {
     set((state) => ({ isLeftBarOpen: !state.isLeftBarOpen }));
+  },
+  setLeftBarOpen: (value: boolean) => {
+    set({ isLeftBarOpen: value });
   },
 }));

--- a/ui/oko_common_ui/src/icons/telegram_icon.tsx
+++ b/ui/oko_common_ui/src/icons/telegram_icon.tsx
@@ -1,6 +1,8 @@
-import type { FC } from "react";
+import { type FC, useId } from "react";
 
 export const TelegramIcon: FC<TelegramIconProps> = ({ size = 20 }) => {
+  const gradientId = useId();
+
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -9,14 +11,14 @@ export const TelegramIcon: FC<TelegramIconProps> = ({ size = 20 }) => {
       viewBox="0 0 20 20"
       fill="none"
     >
-      <circle cx="10" cy="10" r="8.75" fill="url(#paint0_linear_1388_15128)" />
+      <circle cx="10" cy="10" r="8.75" fill={`url(#${gradientId})`} />
       <path
         d="M14.3666 6.38049C14.4445 5.87707 13.9659 5.47972 13.5183 5.67625L4.60301 9.59053C4.28202 9.73146 4.3055 10.2177 4.63842 10.3237L6.47697 10.9092C6.82786 11.0209 7.20783 10.9631 7.51424 10.7514L11.6594 7.88767C11.7844 7.80131 11.9206 7.97904 11.8138 8.08914L8.83007 11.1654C8.54063 11.4638 8.59808 11.9695 8.94623 12.1878L12.2868 14.2827C12.6615 14.5176 13.1436 14.2816 13.2136 13.8288L14.3666 6.38049Z"
         fill="white"
       />
       <defs>
         <linearGradient
-          id="paint0_linear_1388_15128"
+          id={gradientId}
           x1="10"
           y1="1.25"
           x2="10"

--- a/ui/oko_common_ui/src/icons/x_icon.tsx
+++ b/ui/oko_common_ui/src/icons/x_icon.tsx
@@ -1,6 +1,9 @@
-import type { FC } from "react";
+import { type FC, useId } from "react";
 
-export const XIcon: FC<TelegramIconProps> = ({ size = 24 }) => {
+export const XIcon: FC<XIconProps> = ({ size = 24 }) => {
+  const patternId = useId();
+  const imageId = useId();
+
   return (
     <svg
       width={size}
@@ -11,27 +14,21 @@ export const XIcon: FC<TelegramIconProps> = ({ size = 24 }) => {
       xmlnsXlink="http://www.w3.org/1999/xlink"
     >
       <rect x="2" y="2" width="20" height="20" rx="10" fill="#283544" />
-      <rect
-        x="7"
-        y="7"
-        width="10"
-        height="10"
-        fill="url(#pattern0_1385_14849)"
-      />
+      <rect x="7" y="7" width="10" height="10" fill={`url(#${patternId})`} />
       <defs>
         <pattern
-          id="pattern0_1385_14849"
+          id={patternId}
           patternContentUnits="objectBoundingBox"
           width="1"
           height="1"
         >
           <use
-            xlinkHref="#image0_1385_14849"
+            xlinkHref={`#${imageId}`}
             transform="translate(0 -0.0110417) scale(0.000416667)"
           />
         </pattern>
         <image
-          id="image0_1385_14849"
+          id={imageId}
           width="2400"
           height="2453"
           preserveAspectRatio="none"
@@ -42,6 +39,6 @@ export const XIcon: FC<TelegramIconProps> = ({ size = 24 }) => {
   );
 };
 
-export interface TelegramIconProps {
+export interface XIconProps {
   size?: number;
 }

--- a/ui/oko_common_ui/src/menu/menu_item.tsx
+++ b/ui/oko_common_ui/src/menu/menu_item.tsx
@@ -12,6 +12,7 @@ export type MenuItemProps = {
   active: boolean;
   label: string;
   href: string;
+  onClick?: () => void;
 };
 
 export const MenuItem: FC<MenuItemProps> = ({
@@ -19,9 +20,10 @@ export const MenuItem: FC<MenuItemProps> = ({
   Icon,
   active = false,
   href,
+  onClick,
 }) => {
   return (
-    <Link href={href}>
+    <Link href={href} onClick={onClick}>
       <li className={cn(styles.wrapper, { [styles.active]: active })}>
         {Icon}
         <Typography


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [x] I’ve read `CONTRIBUTING.md` and followed the guidelines.

## Summary

User Dashboard 모바일 GNB와 사이드바 구현

### Changes

- 모바일 사이드바에 헤더(Oko 로고 + 닫기 버튼)와 푸터(Feature Request, Get Support) 추가
- 사이드바 z-index 수정 및 전체 폭(100vw) 풀스크린 처리
- 네비게이션 아이템 클릭 시 사이드바 자동 닫힘 지원 (`setLeftBarOpen` 액션 추가)
- 모바일 GNB에 소셜 로그인 아이콘을 원형 배경으로 표시 (Google, Discord, X, Telegram, GitHub, Auth0)
- 드롭다운 오픈 시 아이콘 컨테이너 배경색 변경 (`aria-expanded` 감지)
- 드롭다운 내 이메일 텍스트 모바일 2줄 clamp 처리
- `MenuItem` 컴포넌트에 `onClick` prop 추가

### Modified Files

```
 .../dashboard_header/dashboard_header.module.scss  | 58 ++++++++++++++-
 .../dashboard_header/dashboard_header.tsx          | 70 ++++++++++-------
 .../src/components/left_bar/left_bar.module.scss   | 59 ++++++++++++++-
 .../src/components/left_bar/left_bar.tsx           | 52 +++++++++++++
 apps/user_dashboard/src/state/view.ts              |  4 ++
 ui/oko_common_ui/src/icons/telegram_icon.tsx       |  8 +-
 ui/oko_common_ui/src/icons/x_icon.tsx              | 23 +++---
 ui/oko_common_ui/src/menu/menu_item.tsx            |  4 +-
 8 files changed, 236 insertions(+), 42 deletions(-)
```

## Links (Issue References, etc, if there's any)

<!-- List related issues or PRs (e.g., Closes #123; Related #456). -->
