### PR TITLE
sdk: polyfill Event for RN wallet-standard compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -414,6 +414,7 @@ $RECYCLE.BIN/
 .plan
 .docs
 .omc/
+.omx/
 
 # Postgres
 pg_data/

--- a/apps/attached_proxy_web/src/app/mobile/rpc/_client.tsx
+++ b/apps/attached_proxy_web/src/app/mobile/rpc/_client.tsx
@@ -68,10 +68,17 @@ export function RpcClient({
       // Patch origin for methods that use it.
       // Must use this page's origin (the host that loaded the iframe),
       // not ATTACHED_ORIGIN, because the wallet is stored under host_origin.
+      // Preserve the original origin as app_origin so the attached modal
+      // can still detect demo/sandbox contexts (e.g. custom-scheme origins
+      // like "myapp://" from native apps).
       if (payload && typeof payload === "object" && "data" in payload) {
-        const data = (payload as { data?: { payload?: { origin?: string } } })
-          .data;
+        const data = (
+          payload as {
+            data?: { payload?: { origin?: string; app_origin?: string } };
+          }
+        ).data;
         if (data?.payload && "origin" in data.payload) {
+          data.payload.app_origin = data.payload.origin;
           data.payload.origin = window.location.origin;
         }
       }

--- a/embed/oko_attached/src/components/modal_variants/eth/tx_sig/hooks/use_tx_sig_modal.tsx
+++ b/embed/oko_attached/src/components/modal_variants/eth/tx_sig/hooks/use_tx_sig_modal.tsx
@@ -48,6 +48,9 @@ export function useTxSigModal(args: UseEthereumSigModalArgs) {
   const { closeModal, setError } = useMemoryState();
 
   const hostOrigin = data.payload.origin;
+  const appOrigin = (data.payload as Record<string, unknown>).app_origin as
+    | string
+    | undefined;
   const theme = useAppState().getTheme(hostOrigin);
 
   const [isLoading, setIsLoading] = useState(false);
@@ -159,6 +162,7 @@ export function useTxSigModal(args: UseEthereumSigModalArgs) {
     nonce: nonce,
     client: publicClient,
     hostOrigin: payload.origin,
+    appOrigin,
     options: {
       enabled: isSupportedChain,
     },
@@ -205,7 +209,7 @@ export function useTxSigModal(args: UseEthereumSigModalArgs) {
     getL1GasEstimationError !== null ||
     getFeeCurrencyBalanceError !== null;
 
-  const isDemo = !!hostOrigin && isDemoOrSandboxOrigin(hostOrigin);
+  const isDemo = !!hostOrigin && isDemoOrSandboxOrigin(hostOrigin, appOrigin);
 
   // Fee sponsorship flow for Base chain
   const {

--- a/embed/oko_attached/src/requests/endpoints.ts
+++ b/embed/oko_attached/src/requests/endpoints.ts
@@ -10,17 +10,28 @@ export const DEMO_WEB_ORIGIN = import.meta.env.VITE_DEMO_WEB_ORIGIN;
  * - Matches the configured DEMO_WEB_ORIGIN
  * - Treats non-http(s) origins (e.g. native app custom schemes like `myapp://`)
  *   as sandbox contexts where balance checks should be skipped.
+ *
+ * When the request flows through attached_proxy_web, the original app origin
+ * (e.g. `myapp://`) is replaced with the proxy's https origin for wallet
+ * storage purposes.  The original is preserved as `appOrigin` so we can still
+ * detect native-app sandbox contexts here.
  */
-export function isDemoOrSandboxOrigin(hostOrigin: string): boolean {
-  if (hostOrigin === DEMO_WEB_ORIGIN) {
-    return true;
-  }
-  if (
-    hostOrigin !== "" &&
-    !hostOrigin.startsWith("http://") &&
-    !hostOrigin.startsWith("https://")
-  ) {
-    return true;
+export function isDemoOrSandboxOrigin(
+  hostOrigin: string,
+  appOrigin?: string,
+): boolean {
+  const origins = appOrigin ? [appOrigin, hostOrigin] : [hostOrigin];
+  for (const origin of origins) {
+    if (origin === DEMO_WEB_ORIGIN) {
+      return true;
+    }
+    if (
+      origin !== "" &&
+      !origin.startsWith("http://") &&
+      !origin.startsWith("https://")
+    ) {
+      return true;
+    }
   }
   return false;
 }

--- a/embed/oko_attached/src/web3/ethereum/queries/use_get_gas_estimation.ts
+++ b/embed/oko_attached/src/web3/ethereum/queries/use_get_gas_estimation.ts
@@ -27,6 +27,7 @@ export interface UseGetGasEstimationProps {
   multiplier?: number;
   client?: PublicClient;
   hostOrigin?: string;
+  appOrigin?: string;
   options?: Partial<UseQueryOptions<bigint, StructuredRpcError>>;
 }
 
@@ -39,10 +40,10 @@ export function useGetGasEstimation({
   multiplier = DEFAULT_MULTIPLIER,
   client,
   hostOrigin,
+  appOrigin,
   options,
 }: UseGetGasEstimationProps) {
-  // TODO: Why necessary?
-  const isDemo = !!hostOrigin && isDemoOrSandboxOrigin(hostOrigin);
+  const isDemo = !!hostOrigin && isDemoOrSandboxOrigin(hostOrigin, appOrigin);
   const clampedMultiplier = Math.max(1, Math.min(3, multiplier));
 
   return useQuery({

--- a/sandbox/sandbox_react_native/app/index.tsx
+++ b/sandbox/sandbox_react_native/app/index.tsx
@@ -641,7 +641,7 @@ function SolanaSection({ wallet }: { wallet: OkoWalletRN }) {
 
       const signed = await svm.signTransaction(tx);
       setResult(
-        `Multi SOL Transfer OK: ${Buffer.from(signed.signatures[0]).toString("hex").slice(0, 30)}...`,
+        `Multi SOL Transfer OK: ${Buffer.from(signed.signature!).toString("hex").slice(0, 30)}...`,
       );
     } catch (err) {
       setResult(`Error: ${err}`);
@@ -704,7 +704,7 @@ function SolanaSection({ wallet }: { wallet: OkoWalletRN }) {
 
       const signed = await svm.signTransaction(tx);
       setResult(
-        `Stake OK: ${Buffer.from(signed.signatures[0]).toString("hex").slice(0, 30)}...`,
+        `Stake OK: ${Buffer.from(signed.signature!).toString("hex").slice(0, 30)}...`,
       );
     } catch (err) {
       setResult(`Error: ${err}`);

--- a/sandbox/sandbox_react_native/app/index.tsx
+++ b/sandbox/sandbox_react_native/app/index.tsx
@@ -713,6 +713,100 @@ function SolanaSection({ wallet }: { wallet: OkoWalletRN }) {
     }
   }, [ensureConnected]);
 
+  const handleSwapDemo = useCallback(async () => {
+    setLoading("swap");
+    setResult(null);
+    try {
+      const svm = await ensureConnected();
+      const {
+        Connection,
+        PublicKey,
+        ComputeBudgetProgram,
+        Transaction,
+        TransactionInstruction,
+      } = require("@solana/web3.js");
+
+      const TOKEN_PROGRAM_ID = new PublicKey(
+        "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+      );
+
+      const connection = new Connection(SOLANA_RPC_URL);
+      const { blockhash } = await connection.getLatestBlockhash();
+
+      const tx = new Transaction({
+        recentBlockhash: blockhash,
+        feePayer: svm.publicKey!,
+      });
+
+      // Compute Budget instructions
+      tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }));
+      tx.add(
+        ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1_000 }),
+      );
+
+      // Token Approve instruction
+      const mockTokenAccount = PublicKey.findProgramAddressSync(
+        [
+          svm.publicKey!.toBuffer(),
+          TOKEN_PROGRAM_ID.toBuffer(),
+          new PublicKey(
+            "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+          ).toBuffer(),
+        ],
+        new PublicKey("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"),
+      )[0];
+
+      const approveData = Buffer.alloc(9);
+      approveData.writeUInt8(4, 0);
+      approveData.writeBigUInt64LE(BigInt(1_000_000), 1);
+
+      tx.add(
+        new TransactionInstruction({
+          keys: [
+            { pubkey: mockTokenAccount, isSigner: false, isWritable: true },
+            {
+              pubkey: new PublicKey("11111111111111111111111111111112"),
+              isSigner: false,
+              isWritable: false,
+            },
+            { pubkey: svm.publicKey!, isSigner: true, isWritable: false },
+          ],
+          programId: TOKEN_PROGRAM_ID,
+          data: approveData,
+        }),
+      );
+
+      // Transfer instructions simulating swap internals
+      for (let i = 0; i < 3; i++) {
+        tx.add(
+          new TransactionInstruction({
+            keys: [
+              { pubkey: svm.publicKey!, isSigner: true, isWritable: true },
+              {
+                pubkey: new PublicKey(
+                  `1111111111111111111111111111111${i + 2}`,
+                ),
+                isSigner: false,
+                isWritable: true,
+              },
+            ],
+            programId: TOKEN_PROGRAM_ID,
+            data: Buffer.from([3, ...new Array(8).fill(0)]),
+          }),
+        );
+      }
+
+      const signed = await svm.signTransaction(tx);
+      setResult(
+        `Swap Demo OK: ${Buffer.from(signed.signature!).toString("hex").slice(0, 30)}...`,
+      );
+    } catch (err) {
+      setResult(`Error: ${err}`);
+    } finally {
+      setLoading(null);
+    }
+  }, [ensureConnected]);
+
   return (
     <View style={styles.section}>
       <Text style={styles.h2}>Solana (devnet)</Text>
@@ -749,6 +843,11 @@ function SolanaSection({ wallet }: { wallet: OkoWalletRN }) {
           title="nativeStake"
           onPress={handleNativeStake}
           loading={loading === "stake"}
+        />
+        <Btn
+          title="swapDemo"
+          onPress={handleSwapDemo}
+          loading={loading === "swap"}
         />
       </View>
       {result && <Text style={styles.result}>{result}</Text>}

--- a/sandbox/sandbox_react_native/app/index.tsx
+++ b/sandbox/sandbox_react_native/app/index.tsx
@@ -608,8 +608,8 @@ function SolanaSection({ wallet }: { wallet: OkoWalletRN }) {
     }
   }, [ensureConnected]);
 
-  const handleSignAllTransactions = useCallback(async () => {
-    setLoading("signAll");
+  const handleMultiSolTransfer = useCallback(async () => {
+    setLoading("multiSol");
     setResult(null);
     try {
       const svm = await ensureConnected();
@@ -617,36 +617,95 @@ function SolanaSection({ wallet }: { wallet: OkoWalletRN }) {
         Connection,
         PublicKey,
         SystemProgram,
-        TransactionMessage,
-        VersionedTransaction,
+        Transaction,
         LAMPORTS_PER_SOL,
       } = require("@solana/web3.js");
 
       const connection = new Connection(SOLANA_RPC_URL);
-      const toAddress = new PublicKey("11111111111111111111111111111111");
       const { blockhash } = await connection.getLatestBlockhash();
 
-      const transactions: any[] = [];
+      const tx = new Transaction({
+        recentBlockhash: blockhash,
+        feePayer: svm.publicKey!,
+      });
+
       for (let i = 0; i < 3; i++) {
-        const instructions = [
+        tx.add(
           SystemProgram.transfer({
             fromPubkey: svm.publicKey!,
-            toPubkey: toAddress,
-            lamports: (i + 1) * 0.001 * LAMPORTS_PER_SOL,
+            toPubkey: new PublicKey(`1111111111111111111111111111111${i + 2}`),
+            lamports: (0.0001 + i * 0.0001) * LAMPORTS_PER_SOL,
           }),
-        ];
-
-        const messageV0 = new TransactionMessage({
-          payerKey: svm.publicKey!,
-          recentBlockhash: blockhash,
-          instructions,
-        }).compileToV0Message();
-
-        transactions.push(new VersionedTransaction(messageV0));
+        );
       }
 
-      const signed = await svm.signAllTransactions(transactions);
-      setResult(`SignAll OK (${signed.length} txs signed)`);
+      const signed = await svm.signTransaction(tx);
+      setResult(
+        `Multi SOL Transfer OK: ${Buffer.from(signed.signatures[0]).toString("hex").slice(0, 30)}...`,
+      );
+    } catch (err) {
+      setResult(`Error: ${err}`);
+    } finally {
+      setLoading(null);
+    }
+  }, [ensureConnected]);
+
+  const handleNativeStake = useCallback(async () => {
+    setLoading("stake");
+    setResult(null);
+    try {
+      const svm = await ensureConnected();
+      const {
+        Connection,
+        PublicKey,
+        Keypair,
+        Transaction,
+        StakeProgram,
+        Authorized,
+        Lockup,
+        LAMPORTS_PER_SOL,
+      } = require("@solana/web3.js");
+
+      const connection = new Connection(SOLANA_RPC_URL);
+      const { blockhash } = await connection.getLatestBlockhash();
+
+      const stakeAccount = Keypair.generate();
+      const validatorVoteAccount = new PublicKey(
+        "CertusDeBmqN8ZawdkxK5kFGMwBXdudvWHYwtNgNhvLu",
+      );
+
+      const stakeAmount = 1 * LAMPORTS_PER_SOL;
+      const rentExemptAmount = 2282880;
+
+      const tx = new Transaction({
+        recentBlockhash: blockhash,
+        feePayer: svm.publicKey!,
+      });
+
+      tx.add(
+        StakeProgram.createAccount({
+          fromPubkey: svm.publicKey!,
+          stakePubkey: stakeAccount.publicKey,
+          authorized: new Authorized(svm.publicKey!, svm.publicKey!),
+          lockup: new Lockup(0, 0, svm.publicKey!),
+          lamports: stakeAmount + rentExemptAmount,
+        }),
+      );
+
+      tx.add(
+        StakeProgram.delegate({
+          stakePubkey: stakeAccount.publicKey,
+          authorizedPubkey: svm.publicKey!,
+          votePubkey: validatorVoteAccount,
+        }),
+      );
+
+      tx.partialSign(stakeAccount);
+
+      const signed = await svm.signTransaction(tx);
+      setResult(
+        `Stake OK: ${Buffer.from(signed.signatures[0]).toString("hex").slice(0, 30)}...`,
+      );
     } catch (err) {
       setResult(`Error: ${err}`);
     } finally {
@@ -680,9 +739,16 @@ function SolanaSection({ wallet }: { wallet: OkoWalletRN }) {
           loading={loading === "signTx"}
         />
         <Btn
-          title="signAllTransactions"
-          onPress={handleSignAllTransactions}
-          loading={loading === "signAll"}
+          title="multiSolTransfer"
+          onPress={handleMultiSolTransfer}
+          loading={loading === "multiSol"}
+        />
+      </View>
+      <View style={styles.btnRow}>
+        <Btn
+          title="nativeStake"
+          onPress={handleNativeStake}
+          loading={loading === "stake"}
         />
       </View>
       {result && <Text style={styles.result}>{result}</Text>}

--- a/sandbox/sandbox_react_native/app/index.tsx
+++ b/sandbox/sandbox_react_native/app/index.tsx
@@ -3,6 +3,10 @@ import type { OkoWalletRN } from "@oko-wallet/oko-sdk-core-react-native";
 import { useOkoWallet } from "@oko-wallet/oko-sdk-core-react-native";
 import { OkoCosmosWallet } from "@oko-wallet/oko-sdk-cosmos";
 import { OkoEthWallet } from "@oko-wallet/oko-sdk-eth";
+import {
+  OkoSvmWallet,
+  type OkoSvmWalletInterface,
+} from "@oko-wallet/oko-sdk-svm";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Alert,
@@ -502,18 +506,19 @@ function EthSection({ wallet }: { wallet: OkoWalletRN }) {
 // ─── Solana ───
 
 function SolanaSection({ wallet }: { wallet: OkoWalletRN }) {
-  const svmRef = useMemo<{ current: any }>(() => ({ current: null }), []);
+  const svmRef = useMemo<{ current: OkoSvmWalletInterface | null }>(
+    () => ({ current: null }),
+    [],
+  );
   const [loading, setLoading] = useState<string | null>(null);
   const [result, setResult] = useState<string | null>(null);
 
   const getSvm = useCallback(() => {
     if (!svmRef.current) {
-      require("react-native-get-random-values");
-      const { OkoSvmWallet } = require("@oko-wallet/oko-sdk-svm");
       svmRef.current = new OkoSvmWallet(
         wallet as unknown as OkoWalletInterface,
         { chain_id: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1" },
-      );
+      ) as unknown as OkoSvmWalletInterface;
     }
     return svmRef.current;
   }, [wallet, svmRef]);

--- a/sandbox/sandbox_sol/src/components/ConnectedView.tsx
+++ b/sandbox/sandbox_sol/src/components/ConnectedView.tsx
@@ -5,6 +5,7 @@ import { SignMessageWidget } from "./sign_message_widget";
 import { SignTransactionWidget } from "./sign_transaction_widget";
 import { SiwsWidget } from "./siws_widget";
 import { SplTokenTransferWidget } from "./spl_token_transfer_widget";
+import { SwapDemoWidget } from "./swap_demo_widget";
 import {
   StakingWidget,
   TestTransactionsWidget,
@@ -30,6 +31,7 @@ export default function ConnectedView({
           <SignMessageWidget />
           <SignTransactionWidget />
           <SplTokenTransferWidget />
+          <SwapDemoWidget />
           <StakingWidget />
           <TestTransactionsWidget />
         </div>

--- a/sandbox/sandbox_sol/src/components/swap_demo_widget.tsx
+++ b/sandbox/sandbox_sol/src/components/swap_demo_widget.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import {
+  ComputeBudgetProgram,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import { useState } from "react";
+
+import { DEVNET_CONNECTION } from "@/lib/connection";
+import { useSdkStore } from "@/store/sdk";
+import Button from "./Button";
+
+// Token Program ID
+const TOKEN_PROGRAM_ID = new PublicKey(
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+);
+
+// Mock addresses for demo
+const MOCK_TOKEN_MINT = new PublicKey(
+  "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU", // USDC devnet
+);
+const MOCK_DEX_AUTHORITY = new PublicKey("11111111111111111111111111111112");
+
+/**
+ * Build a Token Program "Approve" instruction manually.
+ * Layout: [1 (Approve discriminator), amount as u64 LE]
+ */
+function createApproveInstruction(
+  tokenAccount: PublicKey,
+  delegate: PublicKey,
+  owner: PublicKey,
+  amount: bigint,
+): TransactionInstruction {
+  const data = Buffer.alloc(9);
+  data.writeUInt8(4, 0); // Approve instruction index
+  data.writeBigUInt64LE(amount, 1);
+
+  return new TransactionInstruction({
+    keys: [
+      { pubkey: tokenAccount, isSigner: false, isWritable: true },
+      { pubkey: delegate, isSigner: false, isWritable: false },
+      { pubkey: owner, isSigner: true, isWritable: false },
+    ],
+    programId: TOKEN_PROGRAM_ID,
+    data,
+  });
+}
+
+export function SwapDemoWidget() {
+  const { okoSvmWallet, publicKey } = useSdkStore();
+  const [isLoading, setIsLoading] = useState(false);
+  const [result, setResult] = useState<{
+    type: "success" | "error";
+    message: string;
+  } | null>(null);
+
+  const handleSwapDemo = async () => {
+    if (!okoSvmWallet || !publicKey) {
+      return;
+    }
+
+    setIsLoading(true);
+    setResult(null);
+
+    try {
+      const fromPubkey = new PublicKey(publicKey);
+      const { blockhash } = await DEVNET_CONNECTION.getLatestBlockhash();
+
+      // Build a mock swap transaction with realistic instruction pattern
+      const tx = new Transaction({
+        recentBlockhash: blockhash,
+        feePayer: fromPubkey,
+      });
+
+      // 1. Compute Budget: Set compute unit limit
+      tx.add(ComputeBudgetProgram.setComputeUnitLimit({ units: 200_000 }));
+
+      // 2. Compute Budget: Set compute unit price (priority fee)
+      tx.add(
+        ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 1_000 }),
+      );
+
+      // 3. Token Program: Approve (allow DEX to spend tokens)
+      const mockTokenAccount = PublicKey.findProgramAddressSync(
+        [
+          fromPubkey.toBuffer(),
+          TOKEN_PROGRAM_ID.toBuffer(),
+          MOCK_TOKEN_MINT.toBuffer(),
+        ],
+        new PublicKey("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"),
+      )[0];
+
+      tx.add(
+        createApproveInstruction(
+          mockTokenAccount,
+          MOCK_DEX_AUTHORITY,
+          fromPubkey,
+          BigInt(1_000_000), // 1 USDC
+        ),
+      );
+
+      // 4-6. Multiple transfers simulating swap internals
+      for (let i = 0; i < 3; i++) {
+        tx.add(
+          new TransactionInstruction({
+            keys: [
+              { pubkey: fromPubkey, isSigner: true, isWritable: true },
+              {
+                pubkey: new PublicKey(
+                  `1111111111111111111111111111111${i + 2}`,
+                ),
+                isSigner: false,
+                isWritable: true,
+              },
+            ],
+            programId: TOKEN_PROGRAM_ID,
+            data: Buffer.from([3, ...new Array(8).fill(0)]), // Transfer instruction
+          }),
+        );
+      }
+
+      const signed = await okoSvmWallet.signTransaction(tx);
+      const sig = Buffer.from(signed.signature!).toString("hex");
+      setResult({ type: "success", message: `Signed: ${sig.slice(0, 40)}...` });
+    } catch (error) {
+      setResult({
+        type: "error",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-white dark:bg-zinc-900 rounded-2xl shadow-sm border border-zinc-200 dark:border-zinc-800 p-6">
+      <h2 className="text-lg font-semibold mb-1">Swap Demo</h2>
+      <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-4">
+        Mock swap transaction with Token Approve + Compute Budget + Transfer
+        instructions (7 messages)
+      </p>
+
+      <Button onClick={handleSwapDemo} disabled={isLoading}>
+        {isLoading ? "Signing..." : "Sign Swap Transaction"}
+      </Button>
+
+      {result && (
+        <div
+          className={`mt-4 p-3 rounded-lg text-sm break-all ${
+            result.type === "success"
+              ? "bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400"
+              : "bg-red-50 dark:bg-red-950/30 text-red-700 dark:text-red-400"
+          }`}
+        >
+          {result.message}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/sdk/oko_sdk_core_react_native/src/index.ts
+++ b/sdk/oko_sdk_core_react_native/src/index.ts
@@ -5,6 +5,32 @@ if (typeof globalThis.Buffer === "undefined") {
   (globalThis as Record<string, unknown>).Buffer = Buffer;
 }
 
+// Polyfill Event for @wallet-standard/wallet compatibility.
+// RegisterWalletEvent extends Event at module scope; without this
+// polyfill, importing @oko-wallet/oko-sdk-svm crashes in React Native.
+if (typeof globalThis.Event === "undefined") {
+  (globalThis as Record<string, unknown>).Event = class Event {
+    readonly type: string;
+    readonly bubbles: boolean;
+    readonly cancelable: boolean;
+    readonly composed: boolean;
+
+    constructor(
+      type: string,
+      init?: { bubbles?: boolean; cancelable?: boolean; composed?: boolean },
+    ) {
+      this.type = type;
+      this.bubbles = init?.bubbles ?? false;
+      this.cancelable = init?.cancelable ?? false;
+      this.composed = init?.composed ?? false;
+    }
+
+    preventDefault() {}
+    stopPropagation() {}
+    stopImmediatePropagation() {}
+  };
+}
+
 export { OkoWalletProvider } from "./OkoWalletProvider";
 export { OkoWalletRN } from "./OkoWalletRN";
 export * from "./types";

--- a/sdk/oko_sdk_svm/src/wallet-standard/sign-in.ts
+++ b/sdk/oko_sdk_svm/src/wallet-standard/sign-in.ts
@@ -10,7 +10,9 @@ export function buildSignInMessage(
 ): string {
   const lines: string[] = [];
 
-  const domain = input.domain ?? window.location.host;
+  const domain =
+    input.domain ??
+    (typeof window !== "undefined" ? window.location.host : "");
   lines.push(`${domain} wants you to sign in with your Solana account:`);
   lines.push(input.address ?? address);
 

--- a/sdk/oko_sdk_svm/src/wallet-standard/sign-in.ts
+++ b/sdk/oko_sdk_svm/src/wallet-standard/sign-in.ts
@@ -11,8 +11,7 @@ export function buildSignInMessage(
   const lines: string[] = [];
 
   const domain =
-    input.domain ??
-    (typeof window !== "undefined" ? window.location.host : "");
+    input.domain ?? (typeof window !== "undefined" ? window.location.host : "");
   lines.push(`${domain} wants you to sign in with your Solana account:`);
   lines.push(input.address ?? address);
 


### PR DESCRIPTION
# Pull Request

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

`@wallet-standard/wallet` has `class RegisterWalletEvent extends Event` at module scope — RN doesn't have `Event`, so importing `oko-sdk-svm` crashes.

- Add `Event` polyfill in `oko_sdk_core_react_native` (same pattern as existing `Buffer` polyfill)
- Guard `window.location.host` in `sign-in.ts`
- Remove lazy `require()` workaround in RN sandbox, use normal import

Zero breaking changes.

## Links (Issue References, etc, if there's any)

OKO-763