### PR TITLE
Fix cross-origin OAuth reauth in export key popup

### DIFF
--- a/apps/user_dashboard/src/app/export_private_key/page.tsx
+++ b/apps/user_dashboard/src/app/export_private_key/page.tsx
@@ -539,7 +539,7 @@ const Page = () => {
         `width=${popupWidth},height=${popupHeight},left=${popupLeft},top=${popupTop},resizable=yes`,
       );
       if (popup) {
-        popup.location.href = `${attachedOrigin}/export/reauth?auth_type=${authType}&email=${encodeURIComponent(email ?? "")}`;
+        popup.location.href = `${attachedOrigin}/export/reauth?auth_type=${authType}&email=${encodeURIComponent(email ?? "")}&host_origin=${encodeURIComponent(window.location.origin)}`;
       }
 
       // 2. Send export request to attached iframe

--- a/embed/oko_attached/src/components/export/use_export_reauth.ts
+++ b/embed/oko_attached/src/components/export/use_export_reauth.ts
@@ -32,6 +32,15 @@ export function findEmbeddedIframe(): Window | null {
   return null;
 }
 
+function getHostOrigin(): string {
+  const params = new URLSearchParams(window.location.search);
+  const hostOrigin = params.get("host_origin");
+  if (hostOrigin) {
+    return hostOrigin;
+  }
+  return window.location.origin;
+}
+
 export function sendReauthParamsToIframe(
   iframe: Window,
   params: { nonce?: string; code_verifier?: string },
@@ -55,7 +64,7 @@ function buildGoogleOAuthUrl(nonce: string): string {
 
   const oauthState: OAuthState = {
     apiKey: "export_key_reauth",
-    targetOrigin: window.location.origin,
+    targetOrigin: getHostOrigin(),
     provider: "google",
   };
 
@@ -76,7 +85,7 @@ function buildXOAuthUrl(codeChallenge: string): string {
 
   const oauthState: OAuthState = {
     apiKey: "export_key_reauth",
-    targetOrigin: window.location.origin,
+    targetOrigin: getHostOrigin(),
     provider: "x",
   };
   const oauthStateString = btoa(JSON.stringify(oauthState));
@@ -98,7 +107,7 @@ function buildDiscordOAuthUrl(codeChallenge: string): string {
 
   const oauthState: OAuthState = {
     apiKey: "export_key_reauth",
-    targetOrigin: window.location.origin,
+    targetOrigin: getHostOrigin(),
     provider: "discord",
   };
   const oauthStateString = btoa(JSON.stringify(oauthState));
@@ -120,7 +129,7 @@ function buildGithubOAuthUrl(codeChallenge: string): string {
 
   const oauthState: OAuthState = {
     apiKey: "export_key_reauth",
-    targetOrigin: window.location.origin,
+    targetOrigin: getHostOrigin(),
     provider: "github",
   };
   const oauthStateString = btoa(JSON.stringify(oauthState));


### PR DESCRIPTION
# Pull Request
> Thank you for raising a Pull Request. Please follow the instruction.

- [x] I’ve read `CONTRIBUTING.md` and followed the guidelines.

Fix OAuth reauth failure in export private key popup due to incorrect targetOrigin

## Summary
- The export reauth popup was using `window.location.origin` (the popup's own origin) as the OAuth `targetOrigin`, which differs from the host app's origin in embedded/cross-origin scenarios
- This caused `postMessage` to fail silently after OAuth redirect, resulting in nonce errors
- Pass `host_origin` query parameter from the host app to the reauth popup, and use it as `targetOrigin` in all OAuth flows (Google, X, Discord, GitHub)

## Changes
<!-- What changed, why it changed, and the impact on users/system. -->

- **`apps/user_dashboard`**: Append `host_origin` query param when opening the reauth popup
- **`embed/oko_attached`**: Add `getHostOrigin()` helper that reads `host_origin` from URL params, falling back to `window.location.origin`. Replace all hardcoded `window.location.origin` references in OAuth URL builders.
<img width="575" height="124" alt="스크린샷 2026-03-16 오후 2 21 18" src="https://github.com/user-attachments/assets/83ac00b7-ccde-4f2a-8423-036c770ce83b" />


## Links (Issue References, etc, if there's any)

<!-- List related issues or PRs (e.g., Closes #123; Related #456). -->
