### PR TITLE
OKO-765

### DIFF
--- a/apps/user_dashboard/src/app/export_private_key/layout.tsx
+++ b/apps/user_dashboard/src/app/export_private_key/layout.tsx
@@ -27,7 +27,7 @@ export default function ExportPrivateKeyLayout({
           </DashboardBody>
         </div>
       </div>
-      <ToastContainer />
+      <ToastContainer stacked={false} />
     </Authorized>
   );
 }

--- a/apps/user_dashboard/src/app/export_private_key/page.module.scss
+++ b/apps/user_dashboard/src/app/export_private_key/page.module.scss
@@ -3,9 +3,13 @@
 .container {
   display: flex;
   flex-wrap: wrap;
-  gap: 64px;
+  gap: 32px;
   align-items: flex-start;
   max-width: 1280px;
+
+  @media (min-width: $desktop_min_width) {
+    gap: 64px;
+  }
 }
 
 .heading {
@@ -13,7 +17,13 @@
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
-  min-width: 300px;
+  min-width: 0;
+  width: 100%;
+
+  @media (min-width: $desktop_min_width) {
+    min-width: 300px;
+    width: auto;
+  }
 }
 
 .headingIcon {
@@ -37,9 +47,13 @@
 
 .content {
   flex: 1 0 0;
-  min-width: 0;
-  max-width: 360px;
+  min-width: 300px;
+  max-width: none;
   padding: 2px 0;
+
+  @media (min-width: $desktop_min_width) {
+    max-width: 360px;
+  }
 }
 
 /* Step 1 styles */

--- a/apps/user_dashboard/src/app/export_private_key/page.tsx
+++ b/apps/user_dashboard/src/app/export_private_key/page.tsx
@@ -607,10 +607,12 @@ const Page = () => {
         const errorType = !resAny.payload.success
           ? resAny.payload.error.type
           : "unknown";
+        const isMobile = window.innerWidth < 769;
         displayToast({
           variant: "confirm",
           title: "Login Failed!",
           description: getExportErrorDescription(errorType),
+          toastOptions: isMobile ? { position: "bottom-center" } : undefined,
         });
       }
     } catch (error) {
@@ -623,10 +625,12 @@ const Page = () => {
         error instanceof Error && error.message === "EXPORT_TIMEOUT"
           ? "Export timed out. Please try again."
           : "Please try again.";
+      const isMobile = window.innerWidth < 769;
       displayToast({
         variant: "confirm",
         title: "Login Failed!",
         description,
+        toastOptions: isMobile ? { position: "bottom-center" } : undefined,
       });
     } finally {
       if (reauthHandler) {

--- a/apps/user_dashboard/src/app/globals.scss
+++ b/apps/user_dashboard/src/app/globals.scss
@@ -54,3 +54,12 @@ a {
     display: none;
   }
 }
+
+.Toastify__toast-container--bottom-center {
+  bottom: 16px;
+  left: 8px;
+  right: 8px;
+  width: auto;
+  transform: none;
+  padding: 0;
+}

--- a/apps/user_dashboard/src/components/toast/index.tsx
+++ b/apps/user_dashboard/src/components/toast/index.tsx
@@ -44,10 +44,12 @@ export function displayToast({
   );
 }
 
-export const ToastContainer: FC = () => {
+export const ToastContainer: FC<{ stacked?: boolean }> = ({
+  stacked = true,
+}) => {
   return (
     <ReactToastifyToastContainer
-      stacked
+      stacked={stacked}
       transition={Bounce}
       toastClassName="custom-toast"
       closeButton={(props) => (


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [x] I’ve read `CONTRIBUTING.md` and followed the guidelines.

user_dashboard: add mobile responsive layout for export private key page

## Summary
- Add responsive layout for the export private key page (flex-wrap stacking on mobile, side-by-side on desktop)
- Show reauth failure toasts at bottom-center on mobile viewports
- Support configurable `stacked` prop on ToastContainer to allow multi-position toasts

## Changes
<!-- What changed, why it changed, and the impact on users/system. -->
- **page.module.scss**: Responsive container gap (32px → 64px), heading full-width on mobile, content max-width only on desktop
- **page.tsx**: Add `position: "bottom-center"` toast option on mobile for reauth error toasts
- **layout.tsx**: Disable stacked mode for export page to support mixed toast positions
- **toast/index.tsx**: Add `stacked` prop to `ToastContainer` (default `true`)
- **globals.scss**: Style bottom-center toast container positioning
<img width="377" height="681" alt="스크린샷 2026-03-16 오후 2 36 53" src="https://github.com/user-attachments/assets/8e4f1fa7-bc52-4337-b6a8-26b894fbfbfb" />

## Links (Issue References, etc, if there's any)

<!-- List related issues or PRs (e.g., Closes #123; Related #456). -->
