### PR TITLE
attached: fix dark mode flickering on login callback pages

### DIFF
--- a/embed/oko_attached/index.html
+++ b/embed/oko_attached/index.html
@@ -5,6 +5,16 @@
     <link rel="icon" type="image/svg+xml" href="/oko_favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Oko Attached" />
+    <meta
+      name="theme-color"
+      content="#ffffff"
+      media="(prefers-color-scheme: light)"
+    />
+    <meta
+      name="theme-color"
+      content="#0c0e12"
+      media="(prefers-color-scheme: dark)"
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://attached.oko.app" />
     <meta property="og:title" content="Oko Attached" />
@@ -15,6 +25,20 @@
       content="https://oko-wallet.s3.ap-northeast-2.amazonaws.com/assets/oko-og-image.png"
     />
     <title>Login - Oko Wallet</title>
+    <script>
+      // Apply system theme before first paint to prevent light-to-dark flash
+      (function () {
+        var isDark =
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches;
+        if (isDark) {
+          document.documentElement.setAttribute("data-theme", "dark");
+          document.documentElement.style.backgroundColor = "#0c0e12";
+        } else {
+          document.documentElement.style.backgroundColor = "#ffffff";
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/embed/oko_attached/index.html
+++ b/embed/oko_attached/index.html
@@ -31,11 +31,20 @@
         var isDark =
           window.matchMedia &&
           window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var isPopup = window.parent === window;
         if (isDark) {
           document.documentElement.setAttribute("data-theme", "dark");
           document.documentElement.style.backgroundColor = "#0c0e12";
         } else {
           document.documentElement.style.backgroundColor = "#ffffff";
+        }
+        // Set color-scheme for popup/standalone contexts so iOS Safari
+        // renders browser chrome (status bar, toolbar) in the correct theme.
+        // Skipped in iframe context to avoid the known black-background bug.
+        if (isPopup) {
+          document.documentElement.style.colorScheme = isDark
+            ? "dark"
+            : "light";
         }
       })();
     </script>

--- a/embed/oko_attached/src/components/attached_initialized/color_scheme.ts
+++ b/embed/oko_attached/src/components/attached_initialized/color_scheme.ts
@@ -8,9 +8,18 @@ export function setColorScheme(theme: Theme) {
 
   root.setAttribute("data-theme", theme);
 
-  // Set color-scheme to support both light and dark
-  // Browser will automatically match parent dApp's color-scheme
-  // This prevents browser from adding opaque background
+  // Clear the inline backgroundColor set by the index.html pre-paint script,
+  // so the CSS variable from global.scss takes over.
+  root.style.backgroundColor = "";
+
+  // Update <meta name="theme-color"> so iOS Safari browser chrome matches.
+  const themeColor = theme === "dark" ? "#0c0e12" : "#ffffff";
+  const metaTags = document.querySelectorAll<HTMLMetaElement>(
+    'meta[name="theme-color"]',
+  );
+  for (const meta of metaTags) {
+    meta.setAttribute("content", themeColor);
+  }
 
   // NOTE - Applying a color-scheme to the body of an iframe causes a bug where,
   // if the host site doesn't have a color-scheme and the browser's default is dark,

--- a/embed/oko_attached/src/components/attached_initialized/color_scheme.ts
+++ b/embed/oko_attached/src/components/attached_initialized/color_scheme.ts
@@ -21,11 +21,15 @@ export function setColorScheme(theme: Theme) {
     meta.setAttribute("content", themeColor);
   }
 
-  // NOTE - Applying a color-scheme to the body of an iframe causes a bug where,
+  // Set color-scheme for popup/standalone contexts so iOS Safari
+  // renders browser chrome (status bar, toolbar) in the correct theme.
+  // NOTE - Applying color-scheme in an iframe causes a bug where,
   // if the host site doesn't have a color-scheme and the browser's default is dark,
-  // the background changes to black.
-  // Therefore, we force a light mode in the iframe(in sdk_core not here) @retto
-  // root.style.colorScheme = "light dark";
+  // the background changes to black. Only apply in popup context. @retto
+  const isPopup = window.parent === window;
+  if (isPopup) {
+    root.style.colorScheme = theme;
+  }
 }
 
 function resolveTheme(theme: Theme): Theme | null {

--- a/embed/oko_attached/src/hooks/theme.ts
+++ b/embed/oko_attached/src/hooks/theme.ts
@@ -17,6 +17,10 @@ export function useSetThemeInCallback(providerType: AuthType) {
   const [_theme, _setTheme] = useState<Theme>(initialTheme);
 
   useLayoutEffect(() => {
+    // Apply system theme synchronously before the async API call
+    // to prevent the white flash on dark-mode devices.
+    setColorScheme(initialTheme);
+
     async function fn() {
       let hostOrigin: string | null = null;
       if (providerType === "google") {

--- a/embed/oko_attached/src/styles/global.scss
+++ b/embed/oko_attached/src/styles/global.scss
@@ -24,7 +24,7 @@ body {
 
 body {
   color: var(--text-primary);
-  // background: var(--bg-primary);
+  background: var(--bg-primary);
   font-family: var(--font-family-body);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/embed/oko_attached/src/styles/global.scss
+++ b/embed/oko_attached/src/styles/global.scss
@@ -24,7 +24,7 @@ body {
 
 body {
   color: var(--text-primary);
-  background: var(--bg-primary);
+  // background: var(--bg-primary);
   font-family: var(--font-family-body);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
# Pull Request

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

When a device is in dark mode, the Attached login callback popup (Google, Auth0, Discord, GitHub, X, Telegram) briefly flashes a white background before switching to dark. Additionally, iOS Safari browser chrome (status bar, safe area) stays white regardless of theme.

**Root cause:**
1. No theme detection before React hydration — first paint always uses light mode CSS defaults
2. `useSetThemeInCallback` only applied theme after an async API call, not synchronously
3. No `<meta name="theme-color">` for iOS Safari
4. `body` background was commented out, leaving it transparent (white)

**Changes:**
- Add inline script in `index.html` `<head>` to detect `prefers-color-scheme: dark` and set `data-theme` + `backgroundColor` before first paint
- Add two `<meta name="theme-color">` tags with media queries for light/dark
- `setColorScheme()` now clears the inline background style and dynamically updates `theme-color` meta tags
- `useSetThemeInCallback` applies system theme synchronously in `useLayoutEffect` before the async API call
- Uncomment `background: var(--bg-primary)` on `body` in `global.scss`

## Links (Issue References, etc, if there's any)

OKO-778