### PR TITLE
OKO-731

### DIFF
--- a/apps/demo_web/src/components/left_bar/left_bar.tsx
+++ b/apps/demo_web/src/components/left_bar/left_bar.tsx
@@ -8,8 +8,8 @@ import type { FC } from "react";
 
 import { IntegrationCard } from "./integration_card/integration_card";
 import styles from "./left_bar.module.scss";
+import { ThemeButton } from "@oko-wallet-demo-web/components/theme/theme_button";
 import { useViewState } from "@oko-wallet-demo-web/state/view";
-// import { ThemeButton } from "@oko-wallet-demo-web/components/theme/theme_button";
 
 export const LeftBar: FC = () => {
   const isLeftBarOpen = useViewState((state) => state.isLeftBarOpen);
@@ -44,7 +44,7 @@ export const LeftBar: FC = () => {
             </>
           )}
 
-          {/* <ThemeButton /> */}
+          <ThemeButton />
         </div>
       </ul>
     </>

--- a/apps/demo_web/src/components/oko_provider/oko_provider.tsx
+++ b/apps/demo_web/src/components/oko_provider/oko_provider.tsx
@@ -4,10 +4,12 @@ import type { FC, PropsWithChildren } from "react";
 
 import { useInitOko } from "@oko-wallet-demo-web/components/oko_provider/use_oko";
 import { useThemeSync } from "@oko-wallet-demo-web/hooks/use_theme_sync";
+import { useThemeSyncToIframe } from "@oko-wallet-demo-web/hooks/use_theme_sync_to_iframe";
 
 export const OkoProvider: FC<PropsWithChildren> = ({ children }) => {
   useInitOko();
   useThemeSync();
+  useThemeSyncToIframe();
 
   return <>{children}</>;
 };

--- a/apps/demo_web/src/hooks/use_theme_sync.ts
+++ b/apps/demo_web/src/hooks/use_theme_sync.ts
@@ -3,14 +3,18 @@ import { useEffect, useLayoutEffect } from "react";
 import { useThemeState } from "@oko-wallet-demo-web/state/theme";
 
 export const useThemeSync = () => {
-  const { setPreference, setTheme } = useThemeState();
+  const { initialize, setTheme } = useThemeState();
+  const preference = useThemeState((s) => s.preference);
 
   useLayoutEffect(() => {
-    // Always follow system theme
-    setPreference("system");
-  }, [setPreference]);
+    initialize();
+  }, [initialize]);
 
   useEffect(() => {
+    if (preference !== "system") {
+      return;
+    }
+
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     const handleChange = (e: MediaQueryListEvent) => {
       setTheme(e.matches ? "dark" : "light");
@@ -18,5 +22,5 @@ export const useThemeSync = () => {
 
     mediaQuery.addEventListener("change", handleChange);
     return () => mediaQuery.removeEventListener("change", handleChange);
-  }, [setTheme]);
+  }, [preference, setTheme]);
 };

--- a/apps/demo_web/src/hooks/use_theme_sync_to_iframe.ts
+++ b/apps/demo_web/src/hooks/use_theme_sync_to_iframe.ts
@@ -16,16 +16,8 @@ export const useThemeSyncToIframe = () => {
   const theme = useThemeState((s) => s.theme);
 
   useEffect(() => {
-    const iframe = document.getElementById(
-      OKO_IFRAME_ID,
-    ) as HTMLIFrameElement | null;
-
-    if (!iframe) {
-      return;
-    }
-
-    const sendTheme = () => {
-      iframe.contentWindow?.postMessage(
+    const sendTheme = (target: HTMLIFrameElement) => {
+      target.contentWindow?.postMessage(
         {
           target: "oko_attached",
           msg_type: "set_theme",
@@ -35,13 +27,34 @@ export const useThemeSyncToIframe = () => {
       );
     };
 
-    // Send immediately for runtime theme changes (iframe already loaded)
-    if (iframe.contentWindow) {
-      sendTheme();
+    const attach = (iframe: HTMLIFrameElement) => {
+      if (iframe.contentWindow) {
+        sendTheme(iframe);
+      }
+      const onLoad = () => sendTheme(iframe);
+      iframe.addEventListener("load", onLoad);
+      return () => iframe.removeEventListener("load", onLoad);
+    };
+
+    const iframe = document.getElementById(
+      OKO_IFRAME_ID,
+    ) as HTMLIFrameElement | null;
+
+    if (iframe) {
+      return attach(iframe);
     }
 
-    // Also send on iframe load for initial page load timing
-    iframe.addEventListener("load", sendTheme);
-    return () => iframe.removeEventListener("load", sendTheme);
+    // iframe not yet in DOM — watch for SDK to create it
+    const observer = new MutationObserver(() => {
+      const el = document.getElementById(
+        OKO_IFRAME_ID,
+      ) as HTMLIFrameElement | null;
+      if (el) {
+        observer.disconnect();
+        attach(el);
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
   }, [theme]);
 };

--- a/apps/demo_web/src/hooks/use_theme_sync_to_iframe.ts
+++ b/apps/demo_web/src/hooks/use_theme_sync_to_iframe.ts
@@ -45,16 +45,20 @@ export const useThemeSyncToIframe = () => {
     }
 
     // iframe not yet in DOM — watch for SDK to create it
+    let detach: (() => void) | undefined;
     const observer = new MutationObserver(() => {
       const el = document.getElementById(
         OKO_IFRAME_ID,
       ) as HTMLIFrameElement | null;
       if (el) {
         observer.disconnect();
-        attach(el);
+        detach = attach(el);
       }
     });
     observer.observe(document.body, { childList: true, subtree: true });
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      detach?.();
+    };
   }, [theme]);
 };

--- a/apps/demo_web/src/hooks/use_theme_sync_to_iframe.ts
+++ b/apps/demo_web/src/hooks/use_theme_sync_to_iframe.ts
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+
+import { useThemeState } from "@oko-wallet-demo-web/state/theme";
+
+const OKO_IFRAME_ID = "oko-attached";
+
+/**
+ * Sends the current resolved theme to the attached iframe via postMessage
+ * whenever it changes. This keeps the Sign Modal's theme in sync with
+ * the Demo web's theme toggle.
+ *
+ * Also sends on iframe load to cover the initial page load case
+ * (new tab with persisted theme that differs from the backend default).
+ */
+export const useThemeSyncToIframe = () => {
+  const theme = useThemeState((s) => s.theme);
+
+  useEffect(() => {
+    const iframe = document.getElementById(
+      OKO_IFRAME_ID,
+    ) as HTMLIFrameElement | null;
+
+    if (!iframe) {
+      return;
+    }
+
+    const sendTheme = () => {
+      iframe.contentWindow?.postMessage(
+        {
+          target: "oko_attached",
+          msg_type: "set_theme",
+          payload: { theme },
+        },
+        "*",
+      );
+    };
+
+    // Send immediately for runtime theme changes (iframe already loaded)
+    if (iframe.contentWindow) {
+      sendTheme();
+    }
+
+    // Also send on iframe load for initial page load timing
+    iframe.addEventListener("load", sendTheme);
+    return () => iframe.removeEventListener("load", sendTheme);
+  }, [theme]);
+};

--- a/embed/oko_attached/src/components/attached_initialized/attached_initialized.tsx
+++ b/embed/oko_attached/src/components/attached_initialized/attached_initialized.tsx
@@ -5,13 +5,18 @@ import type { FC, PropsWithChildren } from "react";
 
 import { useInitializeApp } from "./use_initialize_app";
 import { MobileModeProvider } from "@oko-wallet-attached/hooks/mobile_mode";
+import { useMemoryState } from "@oko-wallet-attached/store/memory";
 
 const isMobile =
   typeof window !== "undefined" &&
   new URLSearchParams(window.location.search).get("mobile") === "true";
 
 export const AttachedInitialized: FC<PropsWithChildren> = ({ children }) => {
-  const { theme } = useInitializeApp();
+  const { theme: initTheme } = useInitializeApp();
+  const memoryTheme = useMemoryState((s) => s.resolvedTheme);
+
+  // After initialization, prefer memory store theme (updated by set_theme messages)
+  const theme = memoryTheme ?? initTheme;
 
   return theme ? (
     <MobileModeProvider enabled={isMobile}>

--- a/embed/oko_attached/src/store/memory/index.ts
+++ b/embed/oko_attached/src/store/memory/index.ts
@@ -14,6 +14,7 @@ const initialState: MemoryState = {
   modalRequest: null,
   error: null,
   referralInfo: null,
+  resolvedTheme: null,
 };
 
 export const useMemoryState = create(
@@ -62,6 +63,9 @@ export const useMemoryState = create(
     },
     clearReferralInfo: () => {
       set({ referralInfo: null });
+    },
+    setResolvedTheme: (theme: "light" | "dark") => {
+      set({ resolvedTheme: theme });
     },
   })),
 );

--- a/embed/oko_attached/src/store/memory/types.ts
+++ b/embed/oko_attached/src/store/memory/types.ts
@@ -21,6 +21,7 @@ export interface MemoryState {
   modalRequest: ModalRequest | null;
   error: AppError | null;
   referralInfo: ReferralInfo | null;
+  resolvedTheme: "light" | "dark" | null;
 }
 
 export interface MemoryActions {
@@ -31,4 +32,5 @@ export interface MemoryActions {
   clearError: () => void;
   setReferralInfo: (info: ReferralInfo) => void;
   clearReferralInfo: () => void;
+  setResolvedTheme: (theme: "light" | "dark") => void;
 }

--- a/embed/oko_attached/src/window_msgs/index.ts
+++ b/embed/oko_attached/src/window_msgs/index.ts
@@ -22,6 +22,8 @@ import { handleSetOAuthNonce } from "./set_oauth_nonce";
 import { handleSignOut } from "./sign_out";
 import { OKO_SDK_TARGET } from "./target";
 import type { MsgEventContext } from "./types";
+import { setColorScheme } from "@oko-wallet-attached/components/attached_initialized/color_scheme";
+import { DEMO_WEB_ORIGIN } from "@oko-wallet-attached/requests/endpoints";
 import { useAppState } from "@oko-wallet-attached/store/app";
 import { useMemoryState } from "@oko-wallet-attached/store/memory";
 
@@ -66,6 +68,24 @@ export function makeMsgHandler() {
         appState.setCodeVerifier(storageOrigin, payload.code_verifier);
       }
       console.debug("[attached] set_reauth_params received", event.origin);
+      return;
+    }
+
+    // set_theme: portless fire-and-forget from demo/sandbox host
+    if (data?.target === "oko_attached" && data?.msg_type === "set_theme") {
+      if (event.origin !== DEMO_WEB_ORIGIN) {
+        console.warn(
+          "[attached] set_theme rejected from origin:",
+          event.origin,
+        );
+        return;
+      }
+      const theme = data.payload?.theme as "light" | "dark" | undefined;
+      if (theme === "light" || theme === "dark") {
+        setColorScheme(theme);
+        useMemoryState.getState().setResolvedTheme(theme);
+        console.debug("[attached] set_theme applied:", theme);
+      }
       return;
     }
 

--- a/sdk/oko_sdk_core/src/types/msg/index.ts
+++ b/sdk/oko_sdk_core/src/types/msg/index.ts
@@ -254,6 +254,19 @@ export type OkoWalletMsgGenerateOAuthUrlAck = {
   payload: Result<{ url: string }, string>;
 };
 
+/**
+ * Portless fire-and-forget message sent from the host window to change
+ * the attached iframe's color theme at runtime.
+ * Only accepted from demo / sandbox origins.
+ */
+export type OkoWalletMsgSetTheme = {
+  target: "oko_attached";
+  msg_type: "set_theme";
+  payload: {
+    theme: "light" | "dark";
+  };
+};
+
 export type OkoWalletMsg =
   | OkoWalletMsgInit
   | OkoWalletMsgInitAck
@@ -291,6 +304,7 @@ export type OkoWalletMsg =
   | OkoWalletMsgImportPrivateKeyAck
   | OkoWalletMsgGenerateOAuthUrl
   | OkoWalletMsgGenerateOAuthUrlAck
+  | OkoWalletMsgSetTheme
   | {
       target: "oko_sdk";
       msg_type: "unknown_msg_type";


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [x] I’ve read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Demo web의 테마 토글을 복원하고, 테마 변경 시 attached iframe(Sign Modal)에 postMessage로 동기화되도록 구현

### Changes

- oko_attached에 portless `set_theme` 메시지 핸들러 추가 (DEMO_WEB_ORIGIN origin 검증)
- memory store에 `resolvedTheme` 상태 추가하여 ThemeProvider를 reactive하게 변경
- SDK msg types에 `OkoWalletMsgSetTheme` 타입 정의
- Demo web의 `ThemeButton` 주석 해제하여 테마 토글 복원
- 새 훅 `useThemeSyncToIframe` 추가 — 테마 변경 및 iframe load 시 postMessage 전송

## Links (Issue References, etc, if there's any)

<!-- List related issues or PRs (e.g., Closes #123; Related #456). -->
