### PR TITLE
oko_attached: fix mobile app signing modal margins and text sizes to match Figma

### DIFF
--- a/embed/oko_attached/src/components/modal/modal.module.scss
+++ b/embed/oko_attached/src/components/modal/modal.module.scss
@@ -35,7 +35,5 @@
 }
 
 :global(html[data-mobile]) .floatingWrapper {
-  max-width: none;
-  padding: 0;
   height: 100%;
 }

--- a/embed/oko_attached/src/components/modal/modal.module.scss
+++ b/embed/oko_attached/src/components/modal/modal.module.scss
@@ -35,5 +35,7 @@
 }
 
 :global(html[data-mobile]) .floatingWrapper {
+  max-width: none;
+  padding: 0;
   height: 100%;
 }

--- a/embed/oko_attached/src/components/modal_variants/common/common_modal.module.scss
+++ b/embed/oko_attached/src/components/modal_variants/common/common_modal.module.scss
@@ -12,6 +12,6 @@
   border-radius: 0;
   border: none;
   box-shadow: none;
-  padding: 32px 20px 16px;
+  padding: 32px 16px 16px;
   height: 100%;
 }

--- a/embed/oko_attached/src/components/modal_variants/common/make_signature/make_sig_modal_code_block_container.module.scss
+++ b/embed/oko_attached/src/components/modal_variants/common/make_signature/make_sig_modal_code_block_container.module.scss
@@ -7,3 +7,9 @@
   overflow: hidden;
   box-sizing: border-box;
 }
+
+// Mobile: overlay scrollbar doesn't reserve gutter space,
+// so increase right padding to compensate (12px + 4px code padding = 16px)
+:global(html[data-mobile]) .codeBlockContainer {
+  padding-right: 12px;
+}

--- a/embed/oko_attached/src/components/modal_variants/common/make_signature/make_signature_modal.module.scss
+++ b/embed/oko_attached/src/components/modal_variants/common/make_signature/make_signature_modal.module.scss
@@ -76,6 +76,13 @@
 
 // ── Mobile app mode overrides ──
 
+:global(html[data-mobile]) .modalInnerContentContainer {
+  margin-left: -16px;
+  margin-right: -16px;
+  padding-left: 16px;
+  padding-right: 12px; // 12px + 4px scrollbar = 16px visual distance
+}
+
 :global(html[data-mobile]) .container {
   height: 100%;
 }

--- a/embed/oko_attached/src/components/modal_variants/common/metadata_content/signer_address_or_email/signer_address_or_email.module.scss
+++ b/embed/oko_attached/src/components/modal_variants/common/metadata_content/signer_address_or_email/signer_address_or_email.module.scss
@@ -31,9 +31,3 @@
 :global(html[data-mobile]) .wrapper {
   flex-wrap: wrap;
 }
-
-// Mobile app mode: enlarge toggle button text
-:global(html[data-mobile]) .changeViewTypeButton p {
-  font-size: var(--font-size-sm);
-  line-height: var(--font-line-height-sm);
-}

--- a/embed/oko_attached/src/components/modal_variants/common/metadata_content/signer_address_or_email/signer_address_or_email.tsx
+++ b/embed/oko_attached/src/components/modal_variants/common/metadata_content/signer_address_or_email/signer_address_or_email.tsx
@@ -58,7 +58,7 @@ export const SignerAddressOrEmailView: FC<ViewProps> = ({
 
   return (
     <>
-      {type === "email" && renderAuthIcon(authType, isMobile ? 20 : 16)}
+      {type === "email" && renderAuthIcon(authType, isMobile ? 24 : 16)}
       <Typography
         size={isMobile ? "md" : "sm"}
         color="brand-tertiary"

--- a/embed/oko_attached/src/components/modal_variants/cosmos/tx_sig/msg/send/send.tsx
+++ b/embed/oko_attached/src/components/modal_variants/cosmos/tx_sig/msg/send/send.tsx
@@ -8,12 +8,14 @@ import { type FC, useMemo } from "react";
 import styles from "../messages.module.scss";
 import { Avatar } from "@oko-wallet-attached/components/avatar/avatar";
 import { TxRow } from "@oko-wallet-attached/components/modal_variants/common/tx_row";
+import { useMobileMode } from "@oko-wallet-attached/hooks/mobile_mode";
 import { useGetMultipleAssetMeta } from "@oko-wallet-attached/web3/cosmos/use_get_asset_meta";
 
 const TokenInfo: FC<{
   chainId: string;
   amount: Coin[];
 }> = ({ chainId, amount }) => {
+  const isMobile = useMobileMode();
   const { data: currencies, isLoading } = useGetMultipleAssetMeta({
     assets: amount.map((coin) => ({
       minimal_denom: coin.denom,
@@ -51,7 +53,7 @@ const TokenInfo: FC<{
           <Avatar
             src={coin.currency?.coinImageUrl}
             alt={coin.currency?.coinMinimalDenom ?? "unknown"}
-            size="sm"
+            size={isMobile ? "md" : "sm"}
             variant="rounded"
           />
           <Typography
@@ -73,6 +75,7 @@ export const SendMessagePretty: FC<{
   amount: Coin[];
   toAddress: string;
 }> = ({ chainId, amount, toAddress }) => {
+  const isMobile = useMobileMode();
   return (
     <div className={styles.container}>
       <TxRow label="Send">
@@ -81,7 +84,7 @@ export const SendMessagePretty: FC<{
       <TxRow label="To">
         <Typography
           color="secondary"
-          size="sm"
+          size={isMobile ? "md" : "sm"}
           weight="medium"
           className={styles.address}
         >

--- a/embed/oko_attached/src/components/modal_variants/eth/tx_sig/actions/common/address_info.tsx
+++ b/embed/oko_attached/src/components/modal_variants/eth/tx_sig/actions/common/address_info.tsx
@@ -5,6 +5,7 @@ import type { Address } from "viem";
 
 import styles from "./address_info.module.scss";
 import { Avatar } from "@oko-wallet-attached/components/avatar/avatar";
+import { useMobileMode } from "@oko-wallet-attached/hooks/mobile_mode";
 import { convertIpfsUrl } from "@oko-wallet-attached/utils/url";
 import {
   useGetENSAvatar,
@@ -16,6 +17,7 @@ export interface AddressInfoProps {
 }
 
 export const AddressInfo: FC<AddressInfoProps> = ({ address }) => {
+  const isMobile = useMobileMode();
   const { data: ensName, isLoading: ensNameIsLoading } = useGetENSName({
     address,
   });
@@ -36,13 +38,13 @@ export const AddressInfo: FC<AddressInfoProps> = ({ address }) => {
         <Avatar
           src={ensAvatar ? convertIpfsUrl(ensAvatar) : undefined}
           alt={ensName ?? "unknown"}
-          size="sm"
+          size={isMobile ? "md" : "sm"}
           variant="rounded"
         />
       ) : null}
       <Typography
         color="secondary"
-        size="sm"
+        size={isMobile ? "md" : "sm"}
         weight="medium"
         className={styles.address}
       >

--- a/embed/oko_attached/src/components/modal_variants/eth/tx_sig/actions/common/token_info.tsx
+++ b/embed/oko_attached/src/components/modal_variants/eth/tx_sig/actions/common/token_info.tsx
@@ -7,6 +7,7 @@ import { type Address, type Chain, createPublicClient, http } from "viem";
 
 import styles from "./token_info.module.scss";
 import { Avatar } from "@oko-wallet-attached/components/avatar/avatar";
+import { useMobileMode } from "@oko-wallet-attached/hooks/mobile_mode";
 import { useGetTokenMetadata } from "@oko-wallet-attached/web3/ethereum/queries";
 import { formatTokenAmount } from "@oko-wallet-attached/web3/ethereum/utils";
 
@@ -40,6 +41,7 @@ export const TokenInfo: FC<TokenInfoProps> = ({
       },
     });
 
+  const isMobile = useMobileMode();
   const tokenImageURI = currency?.coinImageUrl ?? undefined;
 
   // NOTE: currency takes precedence over token metadata
@@ -62,7 +64,7 @@ export const TokenInfo: FC<TokenInfoProps> = ({
       <Avatar
         src={tokenImageURI}
         alt={tokenMetadata.name ?? "unknown"}
-        size="sm"
+        size={isMobile ? "md" : "sm"}
         variant="rounded"
       />
       {formatted.isTruncated ? (

--- a/embed/oko_attached/src/components/modal_variants/svm/all_tx_sig/svm_all_tx_signature_content.tsx
+++ b/embed/oko_attached/src/components/modal_variants/svm/all_tx_sig/svm_all_tx_signature_content.tsx
@@ -7,6 +7,7 @@ import { useMemo } from "react";
 
 import styles from "../common/signature_content.module.scss";
 import { Avatar } from "@oko-wallet-attached/components/avatar/avatar";
+import { useMobileMode } from "@oko-wallet-attached/hooks/mobile_mode";
 import { getChainByChainId } from "@oko-wallet-attached/requests/chain_infos";
 import { getFaviconUrl } from "@oko-wallet-attached/utils/favicon";
 
@@ -19,6 +20,8 @@ export const SvmAllTxSignatureContent: FC<SvmAllTxSignatureContentProps> = ({
 }) => {
   const { origin, chain_id, data } = payload;
   const faviconUrl = getFaviconUrl(origin);
+  const isMobile = useMobileMode();
+  const headingSize = isMobile ? "display-xs" : "lg";
   const txCount = data.serialized_transactions.length;
 
   const { data: chainInfo } = useQuery({
@@ -53,16 +56,16 @@ export const SvmAllTxSignatureContent: FC<SvmAllTxSignatureContentProps> = ({
               className={styles.originFavicon}
             />
           )}
-          <Typography size="lg" color="primary" weight="semibold">
+          <Typography size={headingSize} color="primary" weight="semibold">
             {origin.replace(/^https?:\/\//, "")}
           </Typography>
         </div>
 
-        <Spacing height={4} />
+        <Spacing height={isMobile ? 8 : 4} />
 
         <div className={styles.signInfoColumn}>
           <div className={styles.chainInfoRow}>
-            <Typography size="lg" color="secondary" weight="semibold">
+            <Typography size={headingSize} color="secondary" weight="semibold">
               requested your
             </Typography>
             <div className={styles.chainNameGroup}>
@@ -70,11 +73,11 @@ export const SvmAllTxSignatureContent: FC<SvmAllTxSignatureContentProps> = ({
                 <Avatar
                   src={chainLogoUrl}
                   alt={chainName ?? "chain"}
-                  size="sm"
+                  size={isMobile ? "md" : "sm"}
                   variant="rounded"
                 />
               )}
-              <Typography size="lg" color="secondary" weight="semibold">
+              <Typography size={headingSize} color="secondary" weight="semibold">
                 {chainName ? `${chainName} signatures` : "signatures"}
               </Typography>
             </div>

--- a/embed/oko_attached/src/components/modal_variants/svm/all_tx_sig/svm_all_tx_signature_content.tsx
+++ b/embed/oko_attached/src/components/modal_variants/svm/all_tx_sig/svm_all_tx_signature_content.tsx
@@ -77,7 +77,11 @@ export const SvmAllTxSignatureContent: FC<SvmAllTxSignatureContentProps> = ({
                   variant="rounded"
                 />
               )}
-              <Typography size={headingSize} color="secondary" weight="semibold">
+              <Typography
+                size={headingSize}
+                color="secondary"
+                weight="semibold"
+              >
                 {chainName ? `${chainName} signatures` : "signatures"}
               </Typography>
             </div>

--- a/embed/oko_attached/src/components/modal_variants/svm/common/signature_content.module.scss
+++ b/embed/oko_attached/src/components/modal_variants/svm/common/signature_content.module.scss
@@ -69,6 +69,11 @@
 
 // ── Mobile app mode overrides ──
 
+:global(html[data-mobile]) .originFavicon {
+  width: 24px;
+  height: 24px;
+}
+
 :global(html[data-mobile]) .chainInfoRow {
   row-gap: 8px;
 }

--- a/embed/oko_attached/src/components/modal_variants/svm/message_sig/svm_message_signature_content.tsx
+++ b/embed/oko_attached/src/components/modal_variants/svm/message_sig/svm_message_signature_content.tsx
@@ -10,6 +10,7 @@ import styles from "../common/signature_content.module.scss";
 import { SvmMessageSummary } from "./svm_message_summary";
 import { Avatar } from "@oko-wallet-attached/components/avatar/avatar";
 import { SignerAddressOrEmail } from "@oko-wallet-attached/components/modal_variants/common/metadata_content/signer_address_or_email/signer_address_or_email";
+import { useMobileMode } from "@oko-wallet-attached/hooks/mobile_mode";
 import { getChainByChainId } from "@oko-wallet-attached/requests/chain_infos";
 import { getFaviconUrl } from "@oko-wallet-attached/utils/favicon";
 
@@ -22,6 +23,8 @@ export const SvmMessageSignatureContent: FC<
 > = ({ payload }) => {
   const { origin, signer, chain_id } = payload;
   const faviconUrl = getFaviconUrl(origin);
+  const isMobile = useMobileMode();
+  const headingSize = isMobile ? "display-xs" : "lg";
 
   const { data: chainInfo } = useQuery({
     queryKey: ["chain", chain_id],
@@ -55,16 +58,16 @@ export const SvmMessageSignatureContent: FC<
               className={styles.originFavicon}
             />
           )}
-          <Typography size="lg" color="primary" weight="semibold">
+          <Typography size={headingSize} color="primary" weight="semibold">
             {origin.replace(/^https?:\/\//, "")}
           </Typography>
         </div>
 
-        <Spacing height={4} />
+        <Spacing height={isMobile ? 8 : 4} />
 
         <div className={styles.signInfoColumn}>
           <div className={styles.chainInfoRow}>
-            <Typography size="lg" color="secondary" weight="semibold">
+            <Typography size={headingSize} color="secondary" weight="semibold">
               requested your
             </Typography>
             <div className={styles.chainNameGroup}>
@@ -72,13 +75,13 @@ export const SvmMessageSignatureContent: FC<
                 <Avatar
                   src={chainLogoUrl}
                   alt={chainName ?? "chain"}
-                  size="sm"
+                  size={isMobile ? "md" : "sm"}
                   variant="rounded"
                 />
               ) : (
-                <EmptyStateIcon size={16} />
+                <EmptyStateIcon size={isMobile ? 24 : 16} />
               )}
-              <Typography size="lg" color="secondary" weight="semibold">
+              <Typography size={headingSize} color="secondary" weight="semibold">
                 {chainName ? `${chainName} signature` : "Network signature"}
               </Typography>
             </div>

--- a/embed/oko_attached/src/components/modal_variants/svm/message_sig/svm_message_signature_content.tsx
+++ b/embed/oko_attached/src/components/modal_variants/svm/message_sig/svm_message_signature_content.tsx
@@ -81,7 +81,11 @@ export const SvmMessageSignatureContent: FC<
               ) : (
                 <EmptyStateIcon size={isMobile ? 24 : 16} />
               )}
-              <Typography size={headingSize} color="secondary" weight="semibold">
+              <Typography
+                size={headingSize}
+                color="secondary"
+                weight="semibold"
+              >
                 {chainName ? `${chainName} signature` : "Network signature"}
               </Typography>
             </div>

--- a/embed/oko_attached/src/components/modal_variants/svm/tx_sig/msg/transfer/token_transfer.tsx
+++ b/embed/oko_attached/src/components/modal_variants/svm/tx_sig/msg/transfer/token_transfer.tsx
@@ -7,6 +7,7 @@ import type { FC } from "react";
 import styles from "../instructions.module.scss";
 import { Avatar } from "@oko-wallet-attached/components/avatar/avatar";
 import { TxRow } from "@oko-wallet-attached/components/modal_variants/common/tx_row";
+import { useMobileMode } from "@oko-wallet-attached/hooks/mobile_mode";
 import { useGetSvmTokenMetadata } from "@oko-wallet-attached/web3/svm/queries";
 
 function formatTokenAmount(amount: bigint | number, decimals: number): string {
@@ -39,6 +40,7 @@ export const TokenTransferPretty: FC<TokenTransferPrettyProps> = ({
   to,
   chainId,
 }) => {
+  const isMobile = useMobileMode();
   const { data: tokenMetadata, isLoading } = useGetSvmTokenMetadata({
     mintAddress: mint,
     chainId,
@@ -62,12 +64,12 @@ export const TokenTransferPretty: FC<TokenTransferPrettyProps> = ({
             <Avatar
               src={icon}
               alt={symbol}
-              size="sm"
+              size={isMobile ? "md" : "sm"}
               variant="rounded"
               fallback={symbol.slice(0, 2)}
             />
           ) : (
-            <EmptyStateIcon size={16} />
+            <EmptyStateIcon size={isMobile ? 24 : 16} />
           )}
           {isLoading ? (
             <Skeleton width={80} height={20} />
@@ -116,7 +118,7 @@ export const TokenTransferPretty: FC<TokenTransferPrettyProps> = ({
             className={styles.tokenAddressRow}
             onClick={() => navigator.clipboard.writeText(mint)}
           >
-            <Typography size="sm" weight="medium" className={styles.address}>
+            <Typography size={isMobile ? "md" : "sm"} weight="medium" className={styles.address}>
               {mint}
             </Typography>
             <CopyOutlinedIcon size={16} color="currentColor" />
@@ -127,7 +129,7 @@ export const TokenTransferPretty: FC<TokenTransferPrettyProps> = ({
         <TxRow label="Token">
           <Typography
             color="secondary"
-            size="sm"
+            size={isMobile ? "md" : "sm"}
             weight="medium"
             className={styles.address}
           >
@@ -139,7 +141,7 @@ export const TokenTransferPretty: FC<TokenTransferPrettyProps> = ({
         <TxRow label="to">
           <Typography
             color="secondary"
-            size="sm"
+            size={isMobile ? "md" : "sm"}
             weight="medium"
             className={styles.address}
           >

--- a/embed/oko_attached/src/components/modal_variants/svm/tx_sig/msg/transfer/token_transfer.tsx
+++ b/embed/oko_attached/src/components/modal_variants/svm/tx_sig/msg/transfer/token_transfer.tsx
@@ -118,7 +118,11 @@ export const TokenTransferPretty: FC<TokenTransferPrettyProps> = ({
             className={styles.tokenAddressRow}
             onClick={() => navigator.clipboard.writeText(mint)}
           >
-            <Typography size={isMobile ? "md" : "sm"} weight="medium" className={styles.address}>
+            <Typography
+              size={isMobile ? "md" : "sm"}
+              weight="medium"
+              className={styles.address}
+            >
               {mint}
             </Typography>
             <CopyOutlinedIcon size={16} color="currentColor" />

--- a/embed/oko_attached/src/components/modal_variants/svm/tx_sig/msg/transfer/transfer.tsx
+++ b/embed/oko_attached/src/components/modal_variants/svm/tx_sig/msg/transfer/transfer.tsx
@@ -5,6 +5,7 @@ import styles from "../instructions.module.scss";
 import { Avatar } from "@oko-wallet-attached/components/avatar/avatar";
 import { TxRow } from "@oko-wallet-attached/components/modal_variants/common/tx_row";
 import { SOLANA_LOGO_URL } from "@oko-wallet-attached/constants/urls";
+import { useMobileMode } from "@oko-wallet-attached/hooks/mobile_mode";
 
 function formatLamports(lamports: bigint | number): string {
   // Use scientific notation to avoid floating-point precision issues
@@ -25,11 +26,12 @@ export const SvmTransferPretty: FC<SvmTransferPrettyProps> = ({
   lamports,
   to,
 }) => {
+  const isMobile = useMobileMode();
   return (
     <div className={styles.container}>
       <TxRow label="Send">
         <div className={styles.tokenInfo}>
-          <Avatar src={SOLANA_LOGO_URL} alt="SOL" size="sm" variant="rounded" />
+          <Avatar src={SOLANA_LOGO_URL} alt="SOL" size={isMobile ? "md" : "sm"} variant="rounded" />
           <Typography
             color="secondary"
             size="lg"
@@ -44,7 +46,7 @@ export const SvmTransferPretty: FC<SvmTransferPrettyProps> = ({
         <TxRow label="to">
           <Typography
             color="secondary"
-            size="sm"
+            size={isMobile ? "md" : "sm"}
             weight="medium"
             className={styles.address}
           >

--- a/embed/oko_attached/src/components/modal_variants/svm/tx_sig/msg/transfer/transfer.tsx
+++ b/embed/oko_attached/src/components/modal_variants/svm/tx_sig/msg/transfer/transfer.tsx
@@ -31,7 +31,12 @@ export const SvmTransferPretty: FC<SvmTransferPrettyProps> = ({
     <div className={styles.container}>
       <TxRow label="Send">
         <div className={styles.tokenInfo}>
-          <Avatar src={SOLANA_LOGO_URL} alt="SOL" size={isMobile ? "md" : "sm"} variant="rounded" />
+          <Avatar
+            src={SOLANA_LOGO_URL}
+            alt="SOL"
+            size={isMobile ? "md" : "sm"}
+            variant="rounded"
+          />
           <Typography
             color="secondary"
             size="lg"

--- a/embed/oko_attached/src/components/modal_variants/svm/tx_sig/svm_tx_signature_content.tsx
+++ b/embed/oko_attached/src/components/modal_variants/svm/tx_sig/svm_tx_signature_content.tsx
@@ -10,6 +10,7 @@ import styles from "../common/signature_content.module.scss";
 import { SvmTxSummary } from "./svm_tx_summary";
 import { Avatar } from "@oko-wallet-attached/components/avatar/avatar";
 import { SignerAddressOrEmail } from "@oko-wallet-attached/components/modal_variants/common/metadata_content/signer_address_or_email/signer_address_or_email";
+import { useMobileMode } from "@oko-wallet-attached/hooks/mobile_mode";
 import { getChainByChainId } from "@oko-wallet-attached/requests/chain_infos";
 import type { ParsedTransaction } from "@oko-wallet-attached/tx-parsers/svm/types";
 import { getFaviconUrl } from "@oko-wallet-attached/utils/favicon";
@@ -29,6 +30,8 @@ export const SvmTxSignatureContent: FC<SvmTxSignatureContentProps> = ({
 }) => {
   const { origin, signer, chain_id } = payload;
   const faviconUrl = getFaviconUrl(origin);
+  const isMobile = useMobileMode();
+  const headingSize = isMobile ? "display-xs" : "lg";
 
   const { data: chainInfo } = useQuery({
     queryKey: ["chain", chain_id],
@@ -63,16 +66,16 @@ export const SvmTxSignatureContent: FC<SvmTxSignatureContentProps> = ({
               className={styles.originFavicon}
             />
           )}
-          <Typography size="lg" color="primary" weight="semibold">
+          <Typography size={headingSize} color="primary" weight="semibold">
             {origin.replace(/^https?:\/\//, "")}
           </Typography>
         </div>
 
-        <Spacing height={4} />
+        <Spacing height={isMobile ? 8 : 4} />
 
         <div className={styles.signInfoColumn}>
           <div className={styles.chainInfoRow}>
-            <Typography size="lg" color="secondary" weight="semibold">
+            <Typography size={headingSize} color="secondary" weight="semibold">
               requested your
             </Typography>
             <div className={styles.chainNameGroup}>
@@ -80,13 +83,13 @@ export const SvmTxSignatureContent: FC<SvmTxSignatureContentProps> = ({
                 <Avatar
                   src={chainLogoUrl}
                   alt={chainName ?? "chain"}
-                  size="sm"
+                  size={isMobile ? "md" : "sm"}
                   variant="rounded"
                 />
               ) : (
-                <EmptyStateIcon size={16} />
+                <EmptyStateIcon size={isMobile ? 24 : 16} />
               )}
-              <Typography size="lg" color="secondary" weight="semibold">
+              <Typography size={headingSize} color="secondary" weight="semibold">
                 {chainName ? `${chainName} signature` : "Network signature"}
               </Typography>
             </div>

--- a/embed/oko_attached/src/components/modal_variants/svm/tx_sig/svm_tx_signature_content.tsx
+++ b/embed/oko_attached/src/components/modal_variants/svm/tx_sig/svm_tx_signature_content.tsx
@@ -89,7 +89,11 @@ export const SvmTxSignatureContent: FC<SvmTxSignatureContentProps> = ({
               ) : (
                 <EmptyStateIcon size={isMobile ? 24 : 16} />
               )}
-              <Typography size={headingSize} color="secondary" weight="semibold">
+              <Typography
+                size={headingSize}
+                color="secondary"
+                weight="semibold"
+              >
                 {chainName ? `${chainName} signature` : "Network signature"}
               </Typography>
             </div>


### PR DESCRIPTION
# Pull Request

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Fix mobile app signing modal UI to match Figma design specs:

- **Left/right margins**: Reduce `modalContainer` side padding from 20px to 16px on mobile, with scrollbar-aware asymmetric padding on the scroll area (12px right + 4px scrollbar = 16px visual)
- **Raw view padding**: Fix asymmetric left/right padding in code block container on mobile (overlay scrollbar doesn't reserve gutter space)
- **View Address/Login Info button**: Remove incorrect mobile text enlargement — Figma specifies text-xs/semibold (12px), not text-sm (14px)
- **Send/transfer icons & text**: Enlarge token avatars (16px → 24px) and address text (sm → md) on mobile for EVM, SVM, and Cosmos
- **SVM header text**: Apply mobile size enlargement (display-xs headings, 24px icons) to all 3 SVM signing modals, matching ETH/Cosmos `MetadataContent` pattern
- **Auth icon**: Enlarge Google/auth icon next to email from 20px to 24px on mobile

Desktop/mobile web is unaffected — all changes are scoped to `:global(html[data-mobile])`.

## Links (Issue References, etc, if there's any)

OKO-752