### PR TITLE
user_dashboard: unify modal search and fix chain sort stability

### DIFF
--- a/apps/user_dashboard/src/components/deposit_modal/deposit_modal.tsx
+++ b/apps/user_dashboard/src/components/deposit_modal/deposit_modal.tsx
@@ -55,7 +55,31 @@ export const DepositModal: FC<DepositModalProps> = ({ renderTrigger }) => {
     setSearchQuery(e.target.value);
   };
 
-  const searchFields = ["chainName"];
+  const searchFields = useMemo(
+    () => [
+      "chainName",
+      {
+        key: "currency",
+        function: (chain: ModularChainInfo) => {
+          if (chain.cosmos) {
+            return (
+              chain.cosmos.stakeCurrency?.coinDenom ||
+              chain.cosmos.currencies[0]?.coinDenom ||
+              ""
+            );
+          }
+          if (chain.evm) {
+            return chain.evm.currencies[0]?.coinDenom || "";
+          }
+          if (chain.svm) {
+            return chain.svm.currencies[0]?.coinDenom || "";
+          }
+          return "";
+        },
+      },
+    ],
+    [],
+  );
 
   const visibleChains = useMemo(() => {
     return enabledChains.filter(
@@ -169,7 +193,7 @@ export const DepositModal: FC<DepositModalProps> = ({ renderTrigger }) => {
                   <input
                     type="text"
                     className={styles.searchInput}
-                    placeholder="Search Chains"
+                    placeholder="Search Assets or Chains"
                     value={searchQuery}
                     onChange={handleSearchChange}
                     name="search-chains"

--- a/apps/user_dashboard/src/components/show_hide_chains_modal/show_hide_chains_modal.tsx
+++ b/apps/user_dashboard/src/components/show_hide_chains_modal/show_hide_chains_modal.tsx
@@ -42,6 +42,10 @@ export const ShowHideChainsModal: FC<ShowHideChainsModalProps> = ({
   const isChainEnabled = useChainStore((state) => state.isChainEnabled);
   const enableChains = useChainStore((state) => state.enableChains);
   const disableChains = useChainStore((state) => state.disableChains);
+  const activeUserKey = useChainStore((state) => state.activeUserKey);
+  const enabledChainsByUser = useChainStore(
+    (state) => state.enabledChainsByUser,
+  );
   const { balancesByChainIdentifier } = useAllBalances();
 
   // Track pending toggle overrides as state (chainId → enabled)
@@ -127,14 +131,24 @@ export const ShowHideChainsModal: FC<ShowHideChainsModalProps> = ({
 
   const searchedChains = useSearch(visibleChains, searchQuery, searchFields);
 
+  // Sort using committed store state (not pending overrides) so toggling
+  // inside the modal does not cause chains to jump. Raw state values
+  // (activeUserKey, enabledChainsByUser) are reactive — memo recalculates
+  // after Save updates the store.
   const sortedSearchedChains = useMemo(() => {
+    const userChainIds = activeUserKey
+      ? enabledChainsByUser[activeUserKey]
+      : undefined;
+    const enabledChainIds = userChainIds ?? [...DEFAULT_ENABLED_CHAINS];
+    const enabledSet = new Set(enabledChainIds);
+
     const defaultChainOrder = new Map<string, number>(
       DEFAULT_ENABLED_CHAINS.map((id, index) => [id, index]),
     );
 
     return [...searchedChains].sort((a, b) => {
-      const aIsEnabled = getEffectiveEnabled(a.chainId);
-      const bIsEnabled = getEffectiveEnabled(b.chainId);
+      const aIsEnabled = enabledSet.has(getChainIdentifier(a.chainId));
+      const bIsEnabled = enabledSet.has(getChainIdentifier(b.chainId));
       if (aIsEnabled && !bIsEnabled) {
         return -1;
       }
@@ -173,7 +187,7 @@ export const ShowHideChainsModal: FC<ShowHideChainsModalProps> = ({
 
       return a.chainName.localeCompare(b.chainName);
     });
-  }, [searchedChains, getEffectiveEnabled]);
+  }, [searchedChains, activeUserKey, enabledChainsByUser]);
 
   const getTokenBalances = useCallback(
     (chainId: string): TokenBalance[] => {


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [ ] I’ve read `CONTRIBUTING.md` and followed the guidelines.

## Summary
  - Add asset (coinDenom) search support to Deposit modal, matching Show/Hide Chains modal behavior
  - Fix chain list jumping when toggling chains in Show/Hide Chains modal

  ## Changes
<!-- What changed, why it changed, and the impact on users/system. -->
  - **deposit_modal.tsx**: Add currency search field to `searchFields`, update placeholder to "Search Assets or Chains"
  - **show_hide_chains_modal.tsx**: Replace `getEffectiveEnabled` (includes pending overrides) with raw store state
  (`activeUserKey` + `enabledChainsByUser`) as sort dependency. Chains stay in place during toggling; sort updates
  after Save via store reactivity.

## Links (Issue References, etc, if there's any)

<!-- List related issues or PRs (e.g., Closes #123; Related #456). -->
