### PR TITLE
docs_web: add git hooks setup section to environment-setup

### DIFF
--- a/apps/docs_web/docs/v0/development/environment-setup.md
+++ b/apps/docs_web/docs/v0/development/environment-setup.md
@@ -58,8 +58,8 @@ The project uses [Husky](https://typicode.github.io/husky/) and
 [lint-staged](https://github.com/lint-staged/lint-staged) to run Biome checks
 automatically on staged files before each commit.
 
-Husky is set up via the `prepare` script, which runs automatically after
-`yarn install`. If pre-commit hooks are not firing, run the setup manually:
+Yarn 4 does not run the `prepare` script automatically, so you need to set up
+Husky manually after installing dependencies:
 
 ```bash
 yarn prepare

--- a/apps/docs_web/docs/v0/development/environment-setup.md
+++ b/apps/docs_web/docs/v0/development/environment-setup.md
@@ -52,6 +52,19 @@ yarn ci build_cs
 
 This installs dependencies and builds core packages and Cait Sith.
 
+## Git hooks
+
+The project uses [Husky](https://typicode.github.io/husky/) and
+[lint-staged](https://github.com/lint-staged/lint-staged) to run Biome checks
+automatically on staged files before each commit.
+
+Husky is set up via the `prepare` script, which runs automatically after
+`yarn install`. If pre-commit hooks are not firing, run the setup manually:
+
+```bash
+yarn prepare
+```
+
 ## Docs-only changes
 
 If you are only editing documentation, you do not need to run all services.


### PR DESCRIPTION
# Pull Request

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Add a "Git hooks" section to the environment setup docs explaining Husky + lint-staged pre-commit hook setup and how to fix it when hooks aren't firing.

## Links (Issue References, etc, if there's any)

N/A