### PR TITLE
sdk: remove RN/Expo-specific language from comments for multi-platform support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ Uses `@asteasolutions/zod-to-openapi`. When modifying routes, update both:
 ### Commit Messages
 
 Follow the `<scope>: <description>` format. Scope is the package or area being
-changed. Use lowercase, imperative mood.
+changed. Use lowercase, imperative mood. Always write in English.
 
 ```
 demo_web: fix load listener leak in useThemeSyncToIframe
@@ -139,7 +139,8 @@ project: fix biome lint and format errors
 
 ### Pull Requests
 
-Use the template in `.github/pull_request_template.md`:
+Use the template in `.github/pull_request_template.md`. Always write in English.
+PR title follows the same `<scope>: <description>` format as commit messages.
 
 - Check the `CONTRIBUTING.md` acknowledgement
 - Write a **Summary** explaining what changed, why, and the impact

--- a/apps/attached_proxy_web/src/app/mobile/_shared/rpc_codec.ts
+++ b/apps/attached_proxy_web/src/app/mobile/_shared/rpc_codec.ts
@@ -5,7 +5,7 @@ import pako from "pako";
 
 /**
  * Generic RPC codec for app ↔ attached_proxy_web communication.
- * Mirror of sdk/oko_sdk_core_react_native/src/codec/rpc_codec.ts
+ * Mirror of the mobile SDK RPC codec (e.g. oko_sdk_core_react_native/src/codec/rpc_codec.ts)
  */
 
 export const RPC_CODEC_VERSION = "1";

--- a/sdk/oko_sdk_core/src/types/oko_wallet.ts
+++ b/sdk/oko_sdk_core/src/types/oko_wallet.ts
@@ -27,7 +27,7 @@ export interface OkoWalletStaticInterface {
 
 /**
  * Wallet interface consumed by chain SDKs (eth, cosmos, svm).
- * Both the web OkoWallet and React Native OkoWalletRN implement this.
+ * Platform-specific implementations (web, mobile) implement this.
  */
 export interface OkoWalletInterface {
   origin: string;

--- a/sdk/oko_sdk_core_react_native/src/codec/rpc_codec.ts
+++ b/sdk/oko_sdk_core_react_native/src/codec/rpc_codec.ts
@@ -158,7 +158,7 @@ export function decodeRpcPayload<T>(encoded: string): T {
   return fromEncodedValue(parsed) as T;
 }
 
-// ─── URL helpers (RN SDK side) ───
+// ─── URL helpers (mobile SDK side) ───
 
 export function buildRpcUrl(
   sdkEndpoint: string,

--- a/sdk/oko_sdk_core_react_native/src/native/OkoAuthBrowser.ts
+++ b/sdk/oko_sdk_core_react_native/src/native/OkoAuthBrowser.ts
@@ -4,7 +4,7 @@ import { NativeModules, Platform } from "react-native";
  * SDK-internal callback scheme used by OkoAuthCallbackActivity on Android.
  * The library's AndroidManifest.xml registers this scheme on the
  * CallbackActivity, so Android routes the redirect there without a
- * disambiguation popup. (Expo users can also override via config plugin.)
+ * disambiguation popup. (Overridable via config plugin.)
  */
 export const ANDROID_CALLBACK_SCHEME = "oko.auth.callback";
 
@@ -34,11 +34,10 @@ type AuthOpener = (
 
 /**
  * Detects which auth browser library is available at runtime.
- * Tries expo-web-browser first (backward compat for Expo users),
- * then react-native-inappbrowser-reborn (bare RN users).
+ * Tries expo-web-browser first, then react-native-inappbrowser-reborn.
  */
 function resolveAuthOpener(): AuthOpener {
-  // Try expo-web-browser first (backward compat for existing Expo users)
+  // Try expo-web-browser first
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const WebBrowser = require("expo-web-browser");
@@ -53,7 +52,7 @@ function resolveAuthOpener(): AuthOpener {
     // expo-web-browser not available
   }
 
-  // Fall back to react-native-inappbrowser-reborn (bare RN users)
+  // Fall back to react-native-inappbrowser-reborn
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { InAppBrowser } = require("react-native-inappbrowser-reborn");
@@ -99,8 +98,7 @@ export function getServerRedirectScheme(appScheme: string): string {
  *   ManagementActivity keeps the Custom Tab in the same task as the app.
  *   CallbackActivity receives the redirect and uses CLEAR_TOP to pop
  *   the Custom Tab — no "Open in app?" popup.
- * - iOS: ASWebAuthenticationSession via detected library
- *   (expo-web-browser or react-native-inappbrowser-reborn).
+ * - iOS: ASWebAuthenticationSession via detected auth browser library.
  * - Android (fallback): same as iOS if native module unavailable.
  */
 export async function openAuthSession(


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Remove RN/Expo-specific language from comments across SDK and proxy web packages, preparing for multi-platform mobile SDK expansion (Flutter, Swift, Kotlin).

- `oko_sdk_core`: generalize `OkoWalletInterface` JSDoc from "React Native OkoWalletRN" to "platform-specific implementations (web, mobile)"
- `oko_sdk_core_react_native/OkoAuthBrowser.ts`: remove "Expo users", "backward compat for Expo", "bare RN users" from comments (library names and code untouched)
- `oko_sdk_core_react_native/rpc_codec.ts`: "RN SDK side" → "mobile SDK side"
- `attached_proxy_web/rpc_codec.ts`: generalize mirror comment to platform-neutral

## Links (Issue References, etc, if there's any)

OKO-788