### PR TITLE
[OKO-773] add registration_threshold for partial node signup support

### DIFF
--- a/apps/oko_admin_web/src/components/keyshare_nodes/keyshare_nodes_view.module.scss
+++ b/apps/oko_admin_web/src/components/keyshare_nodes/keyshare_nodes_view.module.scss
@@ -24,3 +24,48 @@
     background: var(--error-700) !important;
   }
 }
+
+.settingsSection {
+  width: 100%;
+  padding: 16px 20px;
+  background: var(--gray-50, #f9fafb);
+  border: 1px solid var(--gray-200, #e5e7eb);
+  border-radius: 8px;
+}
+
+.settingRow {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.settingLabel {
+  font-weight: 600;
+  font-size: 14px;
+  min-width: 180px;
+}
+
+.settingValue {
+  font-size: 14px;
+  color: var(--gray-600, #4b5563);
+}
+
+.settingEdit {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.settingInput {
+  width: 200px;
+  padding: 6px 12px;
+  border: 1px solid var(--gray-300, #d1d5db);
+  border-radius: 6px;
+  font-size: 14px;
+}
+
+.errorText {
+  color: var(--error-600, #dc2626);
+  font-size: 12px;
+  margin-top: 8px;
+}

--- a/apps/oko_admin_web/src/components/keyshare_nodes/keyshare_nodes_view.module.scss
+++ b/apps/oko_admin_web/src/components/keyshare_nodes/keyshare_nodes_view.module.scss
@@ -64,6 +64,11 @@
   font-size: 14px;
 }
 
+.settingHint {
+  font-size: 12px;
+  color: var(--gray-500, #6b7280);
+}
+
 .errorText {
   color: var(--error-600, #dc2626);
   font-size: 12px;

--- a/apps/oko_admin_web/src/components/keyshare_nodes/keyshare_nodes_view.tsx
+++ b/apps/oko_admin_web/src/components/keyshare_nodes/keyshare_nodes_view.tsx
@@ -2,8 +2,9 @@
 
 import { Button } from "@oko-wallet/oko-common-ui/button";
 import { Spacing } from "@oko-wallet/oko-common-ui/spacing";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import type { FC } from "react";
+import { type FC, useState } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { KeyshareNodesTable } from "./keyshare_nodes_table";
@@ -11,11 +12,15 @@ import styles from "./keyshare_nodes_view.module.scss";
 import { useGetTssAllActivationSetting } from "./use_get_tss_all_activation_setting";
 import { useToggleTssAllActivation } from "./use_toggle_tss_all_activation";
 import { TitleHeader } from "@oko-wallet-admin/components/title_header/title_header";
+import { updateKeyShareNodeMeta } from "@oko-wallet-admin/fetch/ks_node";
 import { useAllKeyShareNodes } from "@oko-wallet-admin/fetch/ks_node/use_all_ks_nodes";
 import { paths } from "@oko-wallet-admin/paths";
+import { useAppState } from "@oko-wallet-admin/state";
 
 export const KeyshareNodesView: FC = () => {
   const router = useRouter();
+  const token = useAppState((s) => s.token);
+  const queryClient = useQueryClient();
 
   const { data } = useAllKeyShareNodes();
   const { data: tssAllActivationData } = useGetTssAllActivationSetting();
@@ -39,6 +44,52 @@ export const KeyshareNodesView: FC = () => {
   };
 
   const isActivated = tssAllActivationData?.tss_activation_setting?.is_enabled;
+
+  // Registration threshold state
+  const [regThresholdInput, setRegThresholdInput] = useState<string>("");
+  const [isEditingThreshold, setIsEditingThreshold] = useState(false);
+
+  const { data: metaData, refetch: refetchMeta } = useQuery({
+    queryKey: ["keyShareNodeMeta"],
+    queryFn: async () => {
+      const res = await fetch("/api/admin/key_share_node_meta");
+      return null; // Placeholder — actual value comes from ksNodes data
+    },
+    enabled: false, // We'll get this from the DB directly
+  });
+
+  const updateThresholdMutation = useMutation({
+    mutationFn: (value: number | null) =>
+      updateKeyShareNodeMeta({
+        token: token ?? "",
+        registration_threshold: value,
+      }),
+    onSuccess: () => {
+      setIsEditingThreshold(false);
+      queryClient.invalidateQueries({ queryKey: ["keyShareNodeMeta"] });
+    },
+  });
+
+  const handleSaveThreshold = () => {
+    const value =
+      regThresholdInput === "" ? null : parseInt(regThresholdInput, 10);
+    if (value !== null && Number.isNaN(value)) {
+      return;
+    }
+
+    const displayValue =
+      value === null ? "null (all-or-nothing)" : String(value);
+    const confirmed = confirm(
+      `Are you sure you want to change registration_threshold to ${displayValue}?\n\n` +
+        "This affects how many KS nodes must succeed for sign-up, reshare, and ed25519 keygen.\n" +
+        "Setting this value incorrectly may lock users out of their wallets.",
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    updateThresholdMutation.mutate(value);
+  };
 
   return (
     <div className={styles.wrapper}>
@@ -82,6 +133,58 @@ export const KeyshareNodesView: FC = () => {
           </div>
         )}
       />
+
+      <div className={styles.settingsSection}>
+        <div className={styles.settingRow}>
+          <span className={styles.settingLabel}>Registration Threshold</span>
+          {isEditingThreshold ? (
+            <div className={styles.settingEdit}>
+              <input
+                type="number"
+                min={1}
+                placeholder="null (all-or-nothing)"
+                value={regThresholdInput}
+                onChange={(e) => setRegThresholdInput(e.target.value)}
+                className={styles.settingInput}
+              />
+              <Button
+                variant="primary"
+                onClick={handleSaveThreshold}
+                disabled={updateThresholdMutation.isPending}
+              >
+                Save
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() => setIsEditingThreshold(false)}
+              >
+                Cancel
+              </Button>
+            </div>
+          ) : (
+            <div className={styles.settingEdit}>
+              <span className={styles.settingValue}>
+                {data?.ksNodes ? "—" : "Loading..."}
+              </span>
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  setIsEditingThreshold(true);
+                  setRegThresholdInput("");
+                }}
+              >
+                Edit
+              </Button>
+            </div>
+          )}
+        </div>
+        {updateThresholdMutation.isError && (
+          <div className={styles.errorText}>
+            Failed to update registration threshold
+          </div>
+        )}
+      </div>
+
       <KeyshareNodesTable />
     </div>
   );

--- a/apps/oko_admin_web/src/components/keyshare_nodes/keyshare_nodes_view.tsx
+++ b/apps/oko_admin_web/src/components/keyshare_nodes/keyshare_nodes_view.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@oko-wallet/oko-common-ui/button";
 import { Spacing } from "@oko-wallet/oko-common-ui/spacing";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { type FC, useState } from "react";
 import { FormattedMessage } from "react-intl";
@@ -45,18 +45,15 @@ export const KeyshareNodesView: FC = () => {
 
   const isActivated = tssAllActivationData?.tss_activation_setting?.is_enabled;
 
-  // Registration threshold state
-  const [regThresholdInput, setRegThresholdInput] = useState<string>("");
-  const [isEditingThreshold, setIsEditingThreshold] = useState(false);
+  // Registration threshold state from server
+  const meta = tssAllActivationData?.key_share_node_meta;
+  const sssThreshold = meta?.sss_threshold ?? 2;
+  const currentThreshold = meta?.registration_threshold ?? null;
+  const activeNodes =
+    data?.ksNodes.filter((n) => n.status === "ACTIVE").length ?? 0;
 
-  const { data: metaData, refetch: refetchMeta } = useQuery({
-    queryKey: ["keyShareNodeMeta"],
-    queryFn: async () => {
-      const res = await fetch("/api/admin/key_share_node_meta");
-      return null; // Placeholder — actual value comes from ksNodes data
-    },
-    enabled: false, // We'll get this from the DB directly
-  });
+  const [regThresholdSelect, setRegThresholdSelect] = useState<string>("ALL");
+  const [isEditingThreshold, setIsEditingThreshold] = useState(false);
 
   const updateThresholdMutation = useMutation({
     mutationFn: (value: number | null) =>
@@ -66,23 +63,31 @@ export const KeyshareNodesView: FC = () => {
       }),
     onSuccess: () => {
       setIsEditingThreshold(false);
-      queryClient.invalidateQueries({ queryKey: ["keyShareNodeMeta"] });
+      queryClient.invalidateQueries({
+        queryKey: ["tss-activation-setting"],
+      });
     },
   });
 
+  // Build dropdown options: sssThreshold .. activeNodes + ALL
+  const thresholdOptions: string[] = [];
+  for (let i = sssThreshold; i <= activeNodes; i++) {
+    thresholdOptions.push(String(i));
+  }
+  thresholdOptions.push("ALL");
+
   const handleSaveThreshold = () => {
     const value =
-      regThresholdInput === "" ? null : parseInt(regThresholdInput, 10);
-    if (value !== null && Number.isNaN(value)) {
-      return;
-    }
+      regThresholdSelect === "ALL" ? null : parseInt(regThresholdSelect, 10);
 
-    const displayValue =
-      value === null ? "null (all-or-nothing)" : String(value);
+    const displayValue = value === null ? "ALL" : String(value);
     const confirmed = confirm(
-      `Are you sure you want to change registration_threshold to ${displayValue}?\n\n` +
-        "This affects how many KS nodes must succeed for sign-up, reshare, and ed25519 keygen.\n" +
-        "Setting this value incorrectly may lock users out of their wallets.",
+      `Change Registration Threshold to ${displayValue}?\n\n` +
+        `Active nodes: ${activeNodes} / SSS Threshold: ${sssThreshold}\n\n` +
+        "This determines the minimum number of nodes that must respond\n" +
+        "during sign-up, sign-in (reshare), and Ed25519 key generation.\n\n" +
+        "An incorrect value may block new users from signing up\n" +
+        "or prevent existing users from signing in.",
     );
     if (!confirmed) {
       return;
@@ -96,6 +101,7 @@ export const KeyshareNodesView: FC = () => {
       <TitleHeader
         title="Keyshare Nodes"
         totalCount={data?.ksNodes.length}
+        activeCount={activeNodes}
         renderRightContent={() => (
           <div className={styles.buttonGroup}>
             <a
@@ -136,17 +142,25 @@ export const KeyshareNodesView: FC = () => {
 
       <div className={styles.settingsSection}>
         <div className={styles.settingRow}>
+          <span className={styles.settingLabel}>SSS Threshold</span>
+          <span className={styles.settingValue}>{sssThreshold}</span>
+        </div>
+        <Spacing height={12} />
+        <div className={styles.settingRow}>
           <span className={styles.settingLabel}>Registration Threshold</span>
           {isEditingThreshold ? (
             <div className={styles.settingEdit}>
-              <input
-                type="number"
-                min={1}
-                placeholder="null (all-or-nothing)"
-                value={regThresholdInput}
-                onChange={(e) => setRegThresholdInput(e.target.value)}
+              <select
+                value={regThresholdSelect}
+                onChange={(e) => setRegThresholdSelect(e.target.value)}
                 className={styles.settingInput}
-              />
+              >
+                {thresholdOptions.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
               <Button
                 variant="primary"
                 onClick={handleSaveThreshold}
@@ -164,13 +178,17 @@ export const KeyshareNodesView: FC = () => {
           ) : (
             <div className={styles.settingEdit}>
               <span className={styles.settingValue}>
-                {data?.ksNodes ? "—" : "Loading..."}
+                {currentThreshold === null ? "ALL" : currentThreshold}
               </span>
               <Button
                 variant="secondary"
                 onClick={() => {
                   setIsEditingThreshold(true);
-                  setRegThresholdInput("");
+                  setRegThresholdSelect(
+                    currentThreshold === null
+                      ? "ALL"
+                      : String(currentThreshold),
+                  );
                 }}
               >
                 Edit

--- a/apps/oko_admin_web/src/components/title_header/title_header.tsx
+++ b/apps/oko_admin_web/src/components/title_header/title_header.tsx
@@ -6,6 +6,7 @@ import styles from "./title_header.module.scss";
 interface TitleHeaderProps {
   title: string;
   totalCount?: number;
+  activeCount?: number;
   verifiedCount?: number;
   txGenCount?: number;
   renderRightContent?: () => ReactNode;
@@ -14,6 +15,7 @@ interface TitleHeaderProps {
 export const TitleHeader: FC<TitleHeaderProps> = ({
   title,
   totalCount,
+  activeCount,
   verifiedCount,
   txGenCount,
   renderRightContent,
@@ -33,6 +35,12 @@ export const TitleHeader: FC<TitleHeaderProps> = ({
         {totalCount !== undefined && (
           <div className={styles.countInfo}>
             <span>Total ({totalCount})</span>
+            {activeCount !== undefined && (
+              <>
+                <span className={styles.divider}>/</span>
+                <span>Active ({activeCount})</span>
+              </>
+            )}
             {verifiedCount !== undefined && (
               <>
                 <span className={styles.divider}>/</span>

--- a/apps/oko_admin_web/src/fetch/ks_node/index.ts
+++ b/apps/oko_admin_web/src/fetch/ks_node/index.ts
@@ -6,6 +6,8 @@ import type {
   DeleteKSNodeRequest,
   DeleteKSNodeResponse,
   GetKSNodeByIdResponse,
+  UpdateKeyShareNodeMetaRequest,
+  UpdateKeyShareNodeMetaResponse,
   UpdateKSNodeRequest,
   UpdateKSNodeResponse,
 } from "@oko-wallet/oko-types/admin";
@@ -140,6 +142,32 @@ export async function updateKeyShareNode({
 
   return doFetch<UpdateKSNodeResponse>(
     `${OKO_ADMIN_API_ENDPOINT_V1}/ks_node/update_ks_node`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+export type UpdateKeyShareNodeMetaParams = {
+  token: string;
+  registration_threshold: number | null;
+};
+
+export async function updateKeyShareNodeMeta({
+  token,
+  registration_threshold,
+}: UpdateKeyShareNodeMetaParams) {
+  const body: UpdateKeyShareNodeMetaRequest = {
+    registration_threshold,
+  };
+
+  return doFetch<UpdateKeyShareNodeMetaResponse>(
+    `${OKO_ADMIN_API_ENDPOINT_V1}/ks_node/update_ks_node_meta`,
     {
       method: "POST",
       headers: {

--- a/backend/admin_api/src/api/ks_node/index.ts
+++ b/backend/admin_api/src/api/ks_node/index.ts
@@ -1,3 +1,4 @@
+import { updateRegistrationThreshold } from "@oko-wallet/oko-pg-interface/key_share_node_meta";
 import {
   deleteKSNodeById,
   getAllKSNodesWithHealthCheck,
@@ -18,6 +19,8 @@ import type {
   GetAllKSNodeResponse,
   GetKSNodeByIdRequest,
   GetKSNodeByIdResponse,
+  UpdateKeyShareNodeMetaRequest,
+  UpdateKeyShareNodeMetaResponse,
   UpdateKSNodeRequest,
   UpdateKSNodeResponse,
 } from "@oko-wallet/oko-types/admin";
@@ -323,6 +326,38 @@ export async function deleteKSNode(
       success: false,
       code: "UNKNOWN_ERROR",
       msg: `Failed to delete ksNode: ${err}`,
+    };
+  }
+}
+
+export async function updateKeyShareNodeMeta(
+  db: Pool,
+  body: UpdateKeyShareNodeMetaRequest,
+): Promise<OkoApiResponse<UpdateKeyShareNodeMetaResponse>> {
+  try {
+    const result = await updateRegistrationThreshold(
+      db,
+      body.registration_threshold,
+    );
+    if (!result.success) {
+      return {
+        success: false,
+        code: "INVALID_REQUEST",
+        msg: result.err,
+      };
+    }
+
+    return {
+      success: true,
+      data: {
+        registration_threshold: result.data.registration_threshold,
+      },
+    };
+  } catch (err) {
+    return {
+      success: false,
+      code: "UNKNOWN_ERROR",
+      msg: `Failed to update key share node meta: ${err}`,
     };
   }
 }

--- a/backend/admin_api/src/api/tss/index.ts
+++ b/backend/admin_api/src/api/tss/index.ts
@@ -1,3 +1,4 @@
+import { getKeyShareNodeMeta } from "@oko-wallet/oko-pg-interface/key_share_node_meta";
 import { getTssSessions } from "@oko-wallet/oko-pg-interface/tss";
 import {
   getTssActivationSetting as getTssAllActivationSettingPG,
@@ -94,10 +95,20 @@ export async function getTssAllActivationSetting(
       };
     }
 
+    // Also fetch key_share_node_meta for sss_threshold and registration_threshold
+    const metaRes = await getKeyShareNodeMeta(db);
+    const keyShareNodeMeta = metaRes.success
+      ? {
+          sss_threshold: metaRes.data.sss_threshold,
+          registration_threshold: metaRes.data.registration_threshold,
+        }
+      : undefined;
+
     return {
       success: true,
       data: {
         tss_activation_setting: getTssActivationRes.data,
+        key_share_node_meta: keyShareNodeMeta,
       },
     };
   } catch (error) {

--- a/backend/admin_api/src/routes/index.ts
+++ b/backend/admin_api/src/routes/index.ts
@@ -20,6 +20,7 @@ import { get_wallet_list } from "./get_wallet_list";
 import { resend_customer_user_password } from "./resend_customer_user_password";
 import { set_tss_all_activation_setting } from "./set_tss_all_activation_setting";
 import { update_ks_node } from "./update_ks_node";
+import { update_ks_node_meta } from "./update_ks_node_meta";
 import { user_login } from "./user_login";
 import { user_logout } from "./user_logout";
 import { adminAuthMiddleware } from "@oko-wallet-admin-api/middleware/auth";
@@ -113,6 +114,12 @@ export function makeOkoAdminRouter() {
   router.post("/ks_node/delete_ks_node", adminAuthMiddleware, delete_ks_node);
 
   router.post("/ks_node/update_ks_node", adminAuthMiddleware, update_ks_node);
+
+  router.post(
+    "/ks_node/update_ks_node_meta",
+    adminAuthMiddleware,
+    update_ks_node_meta,
+  );
 
   router.post(
     "/ks_node/activate_ks_node",

--- a/backend/admin_api/src/routes/update_ks_node_meta.ts
+++ b/backend/admin_api/src/routes/update_ks_node_meta.ts
@@ -1,0 +1,90 @@
+import { ErrorCodeMap } from "@oko-wallet/oko-api-error-codes";
+import { registry } from "@oko-wallet/oko-api-openapi";
+import {
+  AdminAuthHeaderSchema,
+  ErrorResponseSchema,
+} from "@oko-wallet/oko-api-openapi/common";
+import {
+  UpdateKeyShareNodeMetaRequestSchema,
+  UpdateKeyShareNodeMetaSuccessResponseSchema,
+} from "@oko-wallet/oko-api-openapi/oko_admin";
+import type {
+  UpdateKeyShareNodeMetaRequest,
+  UpdateKeyShareNodeMetaResponse,
+} from "@oko-wallet/oko-types/admin";
+import type { OkoApiResponse } from "@oko-wallet/oko-types/api_response";
+import type { Response } from "express";
+
+import { updateKeyShareNodeMeta } from "@oko-wallet-admin-api/api/ks_node";
+import type { AuthenticatedAdminRequest } from "@oko-wallet-admin-api/middleware/auth";
+
+registry.registerPath({
+  method: "post",
+  path: "/oko_admin/v1/ks_node/update_ks_node_meta",
+  tags: ["Admin"],
+  summary: "Update key share node metadata",
+  description:
+    "Updates registration_threshold for key share node meta. Value must be >= sss_threshold or null.",
+  security: [{ adminAuth: [] }],
+  request: {
+    headers: AdminAuthHeaderSchema,
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: UpdateKeyShareNodeMetaRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Key share node meta updated successfully",
+      content: {
+        "application/json": {
+          schema: UpdateKeyShareNodeMetaSuccessResponseSchema,
+        },
+      },
+    },
+    400: {
+      description:
+        "Invalid request (e.g., registration_threshold < sss_threshold)",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+    401: {
+      description: "Unauthorized",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+    500: {
+      description: "Server error",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema,
+        },
+      },
+    },
+  },
+});
+
+export async function update_ks_node_meta(
+  req: AuthenticatedAdminRequest<UpdateKeyShareNodeMetaRequest>,
+  res: Response<OkoApiResponse<UpdateKeyShareNodeMetaResponse>>,
+) {
+  const state = req.app.locals;
+
+  const result = await updateKeyShareNodeMeta(state.db, req.body);
+  if (!result.success) {
+    res.status(ErrorCodeMap[result.code] ?? 500).json(result);
+    return;
+  }
+
+  res.status(200).json(result);
+}

--- a/backend/oko_api/server/src/api/tss/ks_node/index.test.ts
+++ b/backend/oko_api/server/src/api/tss/ks_node/index.test.ts
@@ -1,0 +1,421 @@
+import { jest } from "@jest/globals";
+import type { Bytes32, Bytes33 } from "@oko-wallet/bytes";
+import type { OkoApiResponse } from "@oko-wallet/oko-types/api_response";
+import type { AuthType } from "@oko-wallet/oko-types/auth";
+import type { KeyShareNode } from "@oko-wallet/oko-types/tss";
+
+interface CheckKeyShareV2Response {
+  secp256k1?: { exists: boolean };
+  ed25519?: { exists: boolean };
+}
+
+// ── Mock ────────────────────────────────────────────────────────────────
+
+const mockRequestCheckKeyShareV2 =
+  jest.fn<
+    (
+      ksNodeURI: string,
+      userEmail: string,
+      auth_type: AuthType,
+      wallets: { secp256k1?: Bytes33; ed25519?: Bytes32 },
+    ) => Promise<OkoApiResponse<CheckKeyShareV2Response>>
+  >();
+
+const mockRequestCheckKeyShare = jest.fn();
+
+await jest.unstable_mockModule("@oko-wallet-api/requests", () => ({
+  requestCheckKeyShare: mockRequestCheckKeyShare,
+  requestCheckKeyShareV2: mockRequestCheckKeyShareV2,
+}));
+
+const { checkKeyShareFromKSNodesV2 } = await import(
+  "@oko-wallet-api/api/tss/ks_node"
+);
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const TEST_EMAIL = "test@example.com";
+const AUTH_TYPE: AuthType = "google";
+
+function makeKSNodes(count: number): KeyShareNode[] {
+  return Array.from({ length: count }, (_, i) => ({
+    node_id: `node-${i + 1}`,
+    node_name: `KSNode${i + 1}`,
+    status: "ACTIVE" as const,
+    server_url: `http://ks${i + 1}.test`,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }));
+}
+
+const SECP256K1_PK = { toHex: () => "aa".repeat(33) } as unknown as Bytes33;
+const ED25519_PK = { toHex: () => "bb".repeat(32) } as unknown as Bytes32;
+
+function successResponse(
+  secp?: boolean,
+  ed?: boolean,
+): OkoApiResponse<CheckKeyShareV2Response> {
+  const data: CheckKeyShareV2Response = {};
+  if (secp !== undefined) {
+    data.secp256k1 = { exists: secp };
+  }
+  if (ed !== undefined) {
+    data.ed25519 = { exists: ed };
+  }
+  return { success: true, data };
+}
+
+function errorResponse(
+  msg: string,
+  code = "UNKNOWN_ERROR" as const,
+): OkoApiResponse<CheckKeyShareV2Response> {
+  return { success: false, code, msg };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("checkKeyShareFromKSNodesV2", () => {
+  beforeEach(() => {
+    mockRequestCheckKeyShareV2.mockReset();
+  });
+
+  // ── all-or-nothing mode (registrationThreshold not set) ───────────
+
+  describe("all-or-nothing mode (no registrationThreshold)", () => {
+    it("succeeds when all nodes have both curve keyshares", async () => {
+      const nodes = makeKSNodes(3);
+      mockRequestCheckKeyShareV2.mockResolvedValue(successResponse(true, true));
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK, ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+      );
+
+      expect(res.success).toBe(true);
+      if (res.success) {
+        expect(res.data.secp256k1?.nodeIds).toEqual([
+          "node-1",
+          "node-2",
+          "node-3",
+        ]);
+        expect(res.data.ed25519?.nodeIds).toEqual([
+          "node-1",
+          "node-2",
+          "node-3",
+        ]);
+      }
+    });
+
+    it("fails when one node returns secp256k1 exists=false", async () => {
+      const nodes = makeKSNodes(3);
+      mockRequestCheckKeyShareV2
+        .mockResolvedValueOnce(successResponse(true, true))
+        .mockResolvedValueOnce(successResponse(false, true))
+        .mockResolvedValueOnce(successResponse(true, true));
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK, ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+      );
+
+      expect(res.success).toBe(false);
+      if (!res.success) {
+        expect(res.code).toBe("KEYSHARE_NODE_INSUFFICIENT");
+        expect(res.msg).toContain("KSNode2");
+        expect(res.msg).toContain("secp256k1 keyshare does not exist");
+      }
+    });
+
+    it("fails when one node returns ed25519 exists=false", async () => {
+      const nodes = makeKSNodes(2);
+      mockRequestCheckKeyShareV2
+        .mockResolvedValueOnce(successResponse(true, true))
+        .mockResolvedValueOnce(successResponse(true, false));
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK, ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+      );
+
+      expect(res.success).toBe(false);
+      if (!res.success) {
+        expect(res.code).toBe("KEYSHARE_NODE_INSUFFICIENT");
+        expect(res.msg).toContain("KSNode2");
+        expect(res.msg).toContain("ed25519 keyshare does not exist");
+      }
+    });
+
+    it("fails when a node returns error response", async () => {
+      const nodes = makeKSNodes(2);
+      mockRequestCheckKeyShareV2
+        .mockResolvedValueOnce(successResponse(true, true))
+        .mockResolvedValueOnce(errorResponse("node unavailable"));
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK, ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+      );
+
+      expect(res.success).toBe(false);
+      if (!res.success) {
+        expect(res.code).toBe("KEYSHARE_NODE_INSUFFICIENT");
+        expect(res.msg).toContain("node unavailable");
+      }
+    });
+
+    it("returns all nodeIds on success (not just successful ones)", async () => {
+      const nodes = makeKSNodes(3);
+      mockRequestCheckKeyShareV2.mockResolvedValue(successResponse(true, true));
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK, ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+      );
+
+      expect(res.success).toBe(true);
+      if (res.success) {
+        // all-or-nothing returns all nodeIds
+        expect(res.data.secp256k1?.nodeIds).toHaveLength(3);
+        expect(res.data.ed25519?.nodeIds).toHaveLength(3);
+      }
+    });
+  });
+
+  // ── partial success mode (registrationThreshold set) ──────────────
+
+  describe("partial success mode (with registrationThreshold)", () => {
+    it("succeeds when success count meets threshold", async () => {
+      const nodes = makeKSNodes(3);
+      mockRequestCheckKeyShareV2
+        .mockResolvedValueOnce(successResponse(true, true))
+        .mockResolvedValueOnce(successResponse(true, true))
+        .mockResolvedValueOnce(successResponse(false, false));
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK, ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+        2, // registrationThreshold
+      );
+
+      expect(res.success).toBe(true);
+      if (res.success) {
+        expect(res.data.secp256k1?.nodeIds).toEqual(["node-1", "node-2"]);
+        expect(res.data.ed25519?.nodeIds).toEqual(["node-1", "node-2"]);
+      }
+    });
+
+    it("fails when secp256k1 success count is below threshold", async () => {
+      const nodes = makeKSNodes(3);
+      mockRequestCheckKeyShareV2
+        .mockResolvedValueOnce(successResponse(true, true))
+        .mockResolvedValueOnce(successResponse(false, true))
+        .mockResolvedValueOnce(successResponse(false, true));
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK, ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+        2,
+      );
+
+      expect(res.success).toBe(false);
+      if (!res.success) {
+        expect(res.code).toBe("KEYSHARE_NODE_INSUFFICIENT");
+        expect(res.msg).toContain("secp256k1: 1/3 nodes succeeded (need 2)");
+      }
+    });
+
+    it("fails when ed25519 success count is below threshold", async () => {
+      const nodes = makeKSNodes(3);
+      mockRequestCheckKeyShareV2
+        .mockResolvedValueOnce(successResponse(true, true))
+        .mockResolvedValueOnce(successResponse(true, false))
+        .mockResolvedValueOnce(successResponse(true, false));
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK, ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+        2,
+      );
+
+      expect(res.success).toBe(false);
+      if (!res.success) {
+        expect(res.code).toBe("KEYSHARE_NODE_INSUFFICIENT");
+        expect(res.msg).toContain("ed25519: 1/3 nodes succeeded (need 2)");
+      }
+    });
+
+    it("returns only successful nodeIds in partial success mode", async () => {
+      const nodes = makeKSNodes(3);
+      mockRequestCheckKeyShareV2
+        .mockResolvedValueOnce(successResponse(true, true))
+        .mockResolvedValueOnce(errorResponse("connection refused"))
+        .mockResolvedValueOnce(successResponse(true, true));
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK, ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+        2,
+      );
+
+      expect(res.success).toBe(true);
+      if (res.success) {
+        // only node-1 and node-3 succeeded
+        expect(res.data.secp256k1?.nodeIds).toEqual(["node-1", "node-3"]);
+        expect(res.data.ed25519?.nodeIds).toEqual(["node-1", "node-3"]);
+      }
+    });
+
+    it("falls back to all-or-nothing when registrationThreshold is null", async () => {
+      const nodes = makeKSNodes(2);
+      mockRequestCheckKeyShareV2
+        .mockResolvedValueOnce(successResponse(true, true))
+        .mockResolvedValueOnce(successResponse(false, true));
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK, ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+        null,
+      );
+
+      // null → usePartialSuccess = false → all-or-nothing → one failure = fail
+      expect(res.success).toBe(false);
+      if (!res.success) {
+        expect(res.code).toBe("KEYSHARE_NODE_INSUFFICIENT");
+      }
+    });
+  });
+
+  // ── edge cases ────────────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    it("handles Promise rejection from a node", async () => {
+      const nodes = makeKSNodes(3);
+      mockRequestCheckKeyShareV2
+        .mockResolvedValueOnce(successResponse(true, true))
+        .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+        .mockResolvedValueOnce(successResponse(true, true));
+
+      // all-or-nothing: rejection = failure
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK, ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+      );
+
+      expect(res.success).toBe(false);
+      if (!res.success) {
+        expect(res.code).toBe("KEYSHARE_NODE_INSUFFICIENT");
+        expect(res.msg).toContain("KSNode2");
+      }
+    });
+
+    it("handles Promise rejection in partial success mode (above threshold)", async () => {
+      const nodes = makeKSNodes(3);
+      mockRequestCheckKeyShareV2
+        .mockResolvedValueOnce(successResponse(true, true))
+        .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+        .mockResolvedValueOnce(successResponse(true, true));
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK, ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+        2,
+      );
+
+      expect(res.success).toBe(true);
+      if (res.success) {
+        expect(res.data.secp256k1?.nodeIds).toEqual(["node-1", "node-3"]);
+        expect(res.data.ed25519?.nodeIds).toEqual(["node-1", "node-3"]);
+      }
+    });
+
+    it("works with secp256k1-only wallets", async () => {
+      const nodes = makeKSNodes(2);
+      mockRequestCheckKeyShareV2.mockResolvedValue(
+        successResponse(true, undefined),
+      );
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK },
+        nodes,
+        AUTH_TYPE,
+      );
+
+      expect(res.success).toBe(true);
+      if (res.success) {
+        expect(res.data.secp256k1?.nodeIds).toEqual(["node-1", "node-2"]);
+        expect(res.data.ed25519).toBeUndefined();
+      }
+    });
+
+    it("works with ed25519-only wallets", async () => {
+      const nodes = makeKSNodes(2);
+      mockRequestCheckKeyShareV2.mockResolvedValue(
+        successResponse(undefined, true),
+      );
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+      );
+
+      expect(res.success).toBe(true);
+      if (res.success) {
+        expect(res.data.ed25519?.nodeIds).toEqual(["node-1", "node-2"]);
+        expect(res.data.secp256k1).toBeUndefined();
+      }
+    });
+
+    it("per-curve partial failure: secp256k1 below threshold while ed25519 above", async () => {
+      const nodes = makeKSNodes(3);
+      // node-1: both exist
+      // node-2: only ed25519 exists
+      // node-3: only ed25519 exists
+      mockRequestCheckKeyShareV2
+        .mockResolvedValueOnce(successResponse(true, true))
+        .mockResolvedValueOnce(successResponse(false, true))
+        .mockResolvedValueOnce(successResponse(false, true));
+
+      const res = await checkKeyShareFromKSNodesV2(
+        TEST_EMAIL,
+        { secp256k1: SECP256K1_PK, ed25519: ED25519_PK },
+        nodes,
+        AUTH_TYPE,
+        2,
+      );
+
+      // secp256k1 has only 1 success, needs 2 → should fail
+      expect(res.success).toBe(false);
+      if (!res.success) {
+        expect(res.code).toBe("KEYSHARE_NODE_INSUFFICIENT");
+        expect(res.msg).toContain("secp256k1");
+      }
+    });
+  });
+});

--- a/backend/oko_api/server/src/api/tss/ks_node/index.ts
+++ b/backend/oko_api/server/src/api/tss/ks_node/index.ts
@@ -125,6 +125,7 @@ export async function checkKeyShareFromKSNodesV2(
   },
   targetKSNodes: KeyShareNode[],
   auth_type: AuthType,
+  registrationThreshold?: number | null,
 ): Promise<OkoApiResponse<CheckKeyShareV2Result>> {
   try {
     const nodeServerUrls: string[] = [];
@@ -161,12 +162,14 @@ export async function checkKeyShareFromKSNodesV2(
       }),
     );
 
-    // Check all nodes have keyshares for requested curve types
+    const secp256k1SuccessNodeIds: string[] = [];
+    const ed25519SuccessNodeIds: string[] = [];
     const secp256k1Errors: string[] = [];
     const ed25519Errors: string[] = [];
 
     results.forEach((result, index) => {
       const nodeName = targetKSNodes[index].node_name;
+      const nodeId = nodeIds[index];
 
       if (result.status === "rejected") {
         if (wallets.secp256k1) {
@@ -189,41 +192,79 @@ export async function checkKeyShareFromKSNodesV2(
       }
 
       const data = result.value.data;
-      if (wallets.secp256k1 && !data.secp256k1?.exists) {
-        secp256k1Errors.push(
-          `name: ${nodeName}, err: secp256k1 keyshare does not exist`,
-        );
+      if (wallets.secp256k1) {
+        if (data.secp256k1?.exists) {
+          secp256k1SuccessNodeIds.push(nodeId);
+        } else {
+          secp256k1Errors.push(
+            `name: ${nodeName}, err: secp256k1 keyshare does not exist`,
+          );
+        }
       }
-      if (wallets.ed25519 && !data.ed25519?.exists) {
-        ed25519Errors.push(
-          `name: ${nodeName}, err: ed25519 keyshare does not exist`,
-        );
+      if (wallets.ed25519) {
+        if (data.ed25519?.exists) {
+          ed25519SuccessNodeIds.push(nodeId);
+        } else {
+          ed25519Errors.push(
+            `name: ${nodeName}, err: ed25519 keyshare does not exist`,
+          );
+        }
       }
     });
 
-    // All nodes must have keyshares for requested curve types
-    if (wallets.secp256k1 && secp256k1Errors.length > 0) {
-      return {
-        success: false,
-        code: "KEYSHARE_NODE_INSUFFICIENT",
-        msg: secp256k1Errors.join("\n"),
-      };
-    }
+    // When registrationThreshold is set, allow partial success
+    const usePartialSuccess =
+      registrationThreshold != null && registrationThreshold > 0;
 
-    if (wallets.ed25519 && ed25519Errors.length > 0) {
-      return {
-        success: false,
-        code: "KEYSHARE_NODE_INSUFFICIENT",
-        msg: ed25519Errors.join("\n"),
-      };
+    if (usePartialSuccess) {
+      if (
+        wallets.secp256k1 &&
+        secp256k1SuccessNodeIds.length < registrationThreshold
+      ) {
+        return {
+          success: false,
+          code: "KEYSHARE_NODE_INSUFFICIENT",
+          msg: `secp256k1: ${secp256k1SuccessNodeIds.length}/${targetKSNodes.length} nodes succeeded (need ${registrationThreshold})\n${secp256k1Errors.join("\n")}`,
+        };
+      }
+      if (
+        wallets.ed25519 &&
+        ed25519SuccessNodeIds.length < registrationThreshold
+      ) {
+        return {
+          success: false,
+          code: "KEYSHARE_NODE_INSUFFICIENT",
+          msg: `ed25519: ${ed25519SuccessNodeIds.length}/${targetKSNodes.length} nodes succeeded (need ${registrationThreshold})\n${ed25519Errors.join("\n")}`,
+        };
+      }
+    } else {
+      // All nodes must have keyshares (original behavior)
+      if (wallets.secp256k1 && secp256k1Errors.length > 0) {
+        return {
+          success: false,
+          code: "KEYSHARE_NODE_INSUFFICIENT",
+          msg: secp256k1Errors.join("\n"),
+        };
+      }
+      if (wallets.ed25519 && ed25519Errors.length > 0) {
+        return {
+          success: false,
+          code: "KEYSHARE_NODE_INSUFFICIENT",
+          msg: ed25519Errors.join("\n"),
+        };
+      }
     }
 
     const responseData: CheckKeyShareV2Result = {};
     if (wallets.secp256k1) {
-      responseData.secp256k1 = { nodeIds };
+      responseData.secp256k1 = {
+        nodeIds: usePartialSuccess ? secp256k1SuccessNodeIds : nodeIds,
+      };
     }
     if (wallets.ed25519) {
-      responseData.ed25519 = { nodeIds };
+      responseData.ed25519 = {
+        nodeIds: usePartialSuccess ? ed25519SuccessNodeIds : nodeIds,
+      };
     }
 
     return {

--- a/backend/oko_api/server/src/api/tss/sign_ed25519/index.test.ts
+++ b/backend/oko_api/server/src/api/tss/sign_ed25519/index.test.ts
@@ -78,6 +78,7 @@ async function setUpEd25519Wallet(pool: Pool): Promise<TestSetupResult> {
   const _ksNodeIds = await setUpKSNodes(pool);
   await insertKeyShareNodeMeta(pool, {
     sss_threshold: SSS_THRESHOLD,
+    registration_threshold: null,
   });
 
   // Create customer

--- a/backend/oko_api/server/src/api/tss/tss_session/index.test.ts
+++ b/backend/oko_api/server/src/api/tss/tss_session/index.test.ts
@@ -55,6 +55,7 @@ describe("tss_session_test", () => {
     await resetPgDatabase(pool);
     await insertKeyShareNodeMeta(pool, {
       sss_threshold: SSS_THRESHOLD,
+      registration_threshold: null,
     });
   });
 

--- a/backend/oko_api/server/src/api/tss/v1/keygen/index.test.ts
+++ b/backend/oko_api/server/src/api/tss/v1/keygen/index.test.ts
@@ -98,6 +98,7 @@ describe("keygen_v1_test", () => {
     await resetPgDatabase(pool);
     await insertKeyShareNodeMeta(pool, {
       sss_threshold: sssThreshold,
+      registration_threshold: null,
     });
     jest.clearAllMocks();
   });

--- a/backend/oko_api/server/src/api/tss/v1/presign/index.test.ts
+++ b/backend/oko_api/server/src/api/tss/v1/presign/index.test.ts
@@ -143,6 +143,7 @@ async function setUpTssStage(pool: Pool) {
 
   await insertKeyShareNodeMeta(pool, {
     sss_threshold: SSS_THRESHOLD,
+    registration_threshold: null,
   });
 
   const ksNodeIds = await setUpKSNodes(pool);

--- a/backend/oko_api/server/src/api/tss/v1/sign/index.test.ts
+++ b/backend/oko_api/server/src/api/tss/v1/sign/index.test.ts
@@ -153,6 +153,7 @@ async function setUpTssStage(pool: Pool) {
 
   await insertKeyShareNodeMeta(pool, {
     sss_threshold: SSS_THRESHOLD,
+    registration_threshold: null,
   });
 
   const customerId = await createTestCustomer(pool);

--- a/backend/oko_api/server/src/api/tss/v1/triples/index.test.ts
+++ b/backend/oko_api/server/src/api/tss/v1/triples/index.test.ts
@@ -92,6 +92,7 @@ describe("triples_test", () => {
     await resetPgDatabase(pool);
     await insertKeyShareNodeMeta(pool, {
       sss_threshold: SSS_THRESHOLD,
+      registration_threshold: null,
     });
   });
 

--- a/backend/oko_api/server/src/api/tss/v1/user/index.test.ts
+++ b/backend/oko_api/server/src/api/tss/v1/user/index.test.ts
@@ -73,6 +73,7 @@ describe("user_test", () => {
     await resetPgDatabase(pool);
     await insertKeyShareNodeMeta(pool, {
       sss_threshold: SSS_THRESHOLD,
+      registration_threshold: null,
     });
   });
 

--- a/backend/oko_api/server/src/api/tss/v1/user/index.ts
+++ b/backend/oko_api/server/src/api/tss/v1/user/index.ts
@@ -213,6 +213,7 @@ export async function checkEmail(
           exists: false,
           keyshare_node_meta: {
             threshold,
+            registration_threshold: null,
             nodes: activeKSNodes.map((ksNode) => ({
               name: ksNode.node_name,
               endpoint: ksNode.server_url,
@@ -284,6 +285,7 @@ export async function checkEmail(
         exists: true,
         keyshare_node_meta: {
           threshold: wallet.sss_threshold,
+          registration_threshold: null,
           nodes: activeKSNodes.map((ksNode) => ({
             name: ksNode.node_name,
             endpoint: ksNode.server_url,

--- a/backend/oko_api/server/src/api/tss/v2/keygen/index.test.ts
+++ b/backend/oko_api/server/src/api/tss/v2/keygen/index.test.ts
@@ -112,6 +112,7 @@ describe("keygen_v2_test", () => {
     await resetPgDatabase(pool);
     await insertKeyShareNodeMeta(pool, {
       sss_threshold: sssThreshold,
+      registration_threshold: null,
     });
     jest.clearAllMocks();
   });

--- a/backend/oko_api/server/src/api/tss/v2/keygen/index.test.ts
+++ b/backend/oko_api/server/src/api/tss/v2/keygen/index.test.ts
@@ -1366,5 +1366,63 @@ describe("keygen_v2_test", () => {
         }
       }
     });
+
+    it("run runKeygenEd25519 passes registrationThreshold to checkKeyShareFromKSNodesV2", async () => {
+      // Set registration_threshold = 2
+      await insertKeyShareNodeMeta(pool, {
+        sss_threshold: sssThreshold,
+        registration_threshold: 2,
+      });
+
+      const { ksNodeIds } = await setUpUserWithSecp256k1Wallet(pool);
+      (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+        success: true,
+        data: {
+          ed25519: { nodeIds: ksNodeIds },
+        },
+      });
+
+      const keygenResult = runKeygenCentralizedEd25519();
+      const request = generateKeygenRequest(keygenResult);
+
+      await runKeygenEd25519(
+        pool,
+        TEST_JWT_CONFIG_ED25519,
+        request,
+        TEMP_ENC_SECRET,
+        mockLogger,
+      );
+
+      // Verify registrationThreshold (5th arg) was passed as 2
+      expect(mockCheckKeyShareFromKSNodesV2).toHaveBeenCalledTimes(1);
+      const callArgs = mockCheckKeyShareFromKSNodesV2.mock.calls[0];
+      expect(callArgs[4]).toBe(2);
+    });
+
+    it("run runKeygenEd25519 passes null registrationThreshold when not set", async () => {
+      const { ksNodeIds } = await setUpUserWithSecp256k1Wallet(pool);
+      (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+        success: true,
+        data: {
+          ed25519: { nodeIds: ksNodeIds },
+        },
+      });
+
+      const keygenResult = runKeygenCentralizedEd25519();
+      const request = generateKeygenRequest(keygenResult);
+
+      await runKeygenEd25519(
+        pool,
+        TEST_JWT_CONFIG_ED25519,
+        request,
+        TEMP_ENC_SECRET,
+        mockLogger,
+      );
+
+      // Verify registrationThreshold (5th arg) is null (beforeEach sets registration_threshold: null)
+      expect(mockCheckKeyShareFromKSNodesV2).toHaveBeenCalledTimes(1);
+      const callArgs = mockCheckKeyShareFromKSNodesV2.mock.calls[0];
+      expect(callArgs[4]).toBeNull();
+    });
   });
 });

--- a/backend/oko_api/server/src/api/tss/v2/keygen/index.test.ts
+++ b/backend/oko_api/server/src/api/tss/v2/keygen/index.test.ts
@@ -674,6 +674,231 @@ describe("keygen_v2_test", () => {
       expect(keygenResponse.code).toEqual("KEYSHARE_NODE_INSUFFICIENT");
       expect(keygenResponse.msg).toEqual("keyshare node insufficient error");
     });
+
+    it("run keygenV2 partial success - registers only successful nodes as wallet_ks_nodes", async () => {
+      const secp256k1KeygenResult = napiRunKeygenClientCentralized();
+      const ed25519KeygenResult = runKeygenCentralizedEd25519();
+
+      const keygen_2_secp256k1 =
+        secp256k1KeygenResult.keygen_outputs[Participant.P1];
+      const keygen_2_ed25519 =
+        ed25519KeygenResult.keygen_outputs[Participant.P1];
+
+      const keygenRequest: KeygenRequestV2 = {
+        auth_type: "google",
+        user_identifier: "test@test.com",
+        email: "test@test.com",
+        keygen_2_secp256k1: {
+          public_key: keygen_2_secp256k1.public_key,
+          private_share: keygen_2_secp256k1.private_share,
+        },
+        keygen_2_ed25519: {
+          key_package: keygen_2_ed25519.key_package,
+          public_key_package: keygen_2_ed25519.public_key_package,
+          identifier: [...keygen_2_ed25519.identifier],
+          public_key: [...ed25519KeygenResult.public_key],
+        },
+        ed25519_seed_share: TEST_SEED_SHARE,
+      };
+
+      const jwtConfig = {
+        secret: "test-jwt-secret",
+        expires_in: "1h",
+      };
+
+      // Set registration_threshold = 2
+      await insertKeyShareNodeMeta(pool, {
+        sss_threshold: sssThreshold,
+        registration_threshold: 2,
+      });
+
+      // Set up 3 KS nodes but mock returns only 2 (partial success)
+      const ksNodeNames = ["ksNode1", "ksNode2", "ksNode3"];
+      const ksNodeIds: string[] = [];
+      const createKSNodesRes = await Promise.all(
+        ksNodeNames.map((ksNodeName) =>
+          insertKSNode(pool, ksNodeName, `http://test.com/${ksNodeName}`),
+        ),
+      );
+      for (const res of createKSNodesRes) {
+        if (res.success === false) {
+          throw new Error("Failed to create ks nodes");
+        }
+        ksNodeIds.push(res.data.node_id);
+      }
+
+      // Mock returns only first 2 nodes (node 3 "failed")
+      const successNodeIds = [ksNodeIds[0], ksNodeIds[1]];
+      (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+        success: true,
+        data: {
+          secp256k1: { nodeIds: successNodeIds },
+          ed25519: { nodeIds: successNodeIds },
+        },
+      });
+
+      const customerId = await createTestCustomer(pool);
+
+      const keygenResponse = await runKeygenV2(
+        pool,
+        jwtConfig,
+        keygenRequest,
+        TEMP_ENC_SECRET,
+        mockLogger,
+        customerId,
+      );
+      if (keygenResponse.success === false) {
+        console.error(keygenResponse);
+        throw new Error("Failed to run keygenV2");
+      }
+
+      expect(keygenResponse.success).toBe(true);
+
+      // Verify only successful nodes are registered as wallet_ks_nodes
+      const secp256k1KSNodesRes = await getWalletKSNodesByWalletId(
+        pool,
+        keygenResponse.data?.user.wallet_id_secp256k1,
+      );
+      if (secp256k1KSNodesRes.success === false) {
+        throw new Error("Failed to get secp256k1 wallet KS nodes");
+      }
+      expect(secp256k1KSNodesRes.data).toHaveLength(2);
+      expect(secp256k1KSNodesRes.data.map((n) => n.node_id).sort()).toEqual(
+        successNodeIds.sort(),
+      );
+
+      const ed25519KSNodesRes = await getWalletKSNodesByWalletId(
+        pool,
+        keygenResponse.data?.user.wallet_id_ed25519,
+      );
+      if (ed25519KSNodesRes.success === false) {
+        throw new Error("Failed to get ed25519 wallet KS nodes");
+      }
+      expect(ed25519KSNodesRes.data).toHaveLength(2);
+      expect(ed25519KSNodesRes.data.map((n) => n.node_id).sort()).toEqual(
+        successNodeIds.sort(),
+      );
+    });
+
+    it("run keygenV2 passes registrationThreshold to checkKeyShareFromKSNodesV2", async () => {
+      const secp256k1KeygenResult = napiRunKeygenClientCentralized();
+      const ed25519KeygenResult = runKeygenCentralizedEd25519();
+
+      const keygen_2_secp256k1 =
+        secp256k1KeygenResult.keygen_outputs[Participant.P1];
+      const keygen_2_ed25519 =
+        ed25519KeygenResult.keygen_outputs[Participant.P1];
+
+      const keygenRequest: KeygenRequestV2 = {
+        auth_type: "google",
+        user_identifier: "test@test.com",
+        email: "test@test.com",
+        keygen_2_secp256k1: {
+          public_key: keygen_2_secp256k1.public_key,
+          private_share: keygen_2_secp256k1.private_share,
+        },
+        keygen_2_ed25519: {
+          key_package: keygen_2_ed25519.key_package,
+          public_key_package: keygen_2_ed25519.public_key_package,
+          identifier: [...keygen_2_ed25519.identifier],
+          public_key: [...ed25519KeygenResult.public_key],
+        },
+        ed25519_seed_share: TEST_SEED_SHARE,
+      };
+
+      const jwtConfig = {
+        secret: "test-jwt-secret",
+        expires_in: "1h",
+      };
+
+      // Set registration_threshold = 2
+      await insertKeyShareNodeMeta(pool, {
+        sss_threshold: sssThreshold,
+        registration_threshold: 2,
+      });
+
+      const ksNodeIds = await setUpKSNodes(pool);
+      (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+        success: true,
+        data: {
+          secp256k1: { nodeIds: ksNodeIds },
+          ed25519: { nodeIds: ksNodeIds },
+        },
+      });
+
+      const customerId = await createTestCustomer(pool);
+
+      await runKeygenV2(
+        pool,
+        jwtConfig,
+        keygenRequest,
+        TEMP_ENC_SECRET,
+        mockLogger,
+        customerId,
+      );
+
+      // Verify registrationThreshold (5th arg) was passed as 2
+      expect(mockCheckKeyShareFromKSNodesV2).toHaveBeenCalledTimes(1);
+      const callArgs = mockCheckKeyShareFromKSNodesV2.mock.calls[0];
+      expect(callArgs[4]).toBe(2);
+    });
+
+    it("run keygenV2 passes null registrationThreshold when not set", async () => {
+      const secp256k1KeygenResult = napiRunKeygenClientCentralized();
+      const ed25519KeygenResult = runKeygenCentralizedEd25519();
+
+      const keygen_2_secp256k1 =
+        secp256k1KeygenResult.keygen_outputs[Participant.P1];
+      const keygen_2_ed25519 =
+        ed25519KeygenResult.keygen_outputs[Participant.P1];
+
+      const keygenRequest: KeygenRequestV2 = {
+        auth_type: "google",
+        user_identifier: "test@test.com",
+        email: "test@test.com",
+        keygen_2_secp256k1: {
+          public_key: keygen_2_secp256k1.public_key,
+          private_share: keygen_2_secp256k1.private_share,
+        },
+        keygen_2_ed25519: {
+          key_package: keygen_2_ed25519.key_package,
+          public_key_package: keygen_2_ed25519.public_key_package,
+          identifier: [...keygen_2_ed25519.identifier],
+          public_key: [...ed25519KeygenResult.public_key],
+        },
+        ed25519_seed_share: TEST_SEED_SHARE,
+      };
+
+      const jwtConfig = {
+        secret: "test-jwt-secret",
+        expires_in: "1h",
+      };
+
+      const ksNodeIds = await setUpKSNodes(pool);
+      (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+        success: true,
+        data: {
+          secp256k1: { nodeIds: ksNodeIds },
+          ed25519: { nodeIds: ksNodeIds },
+        },
+      });
+
+      const customerId = await createTestCustomer(pool);
+
+      await runKeygenV2(
+        pool,
+        jwtConfig,
+        keygenRequest,
+        TEMP_ENC_SECRET,
+        mockLogger,
+        customerId,
+      );
+
+      // Verify registrationThreshold (5th arg) is null (beforeEach sets registration_threshold: null)
+      expect(mockCheckKeyShareFromKSNodesV2).toHaveBeenCalledTimes(1);
+      const callArgs = mockCheckKeyShareFromKSNodesV2.mock.calls[0];
+      expect(callArgs[4]).toBeNull();
+    });
   });
 
   describe("runKeygenEd25519", () => {

--- a/backend/oko_api/server/src/api/tss/v2/keygen/index.test.ts
+++ b/backend/oko_api/server/src/api/tss/v2/keygen/index.test.ts
@@ -743,7 +743,7 @@ describe("keygen_v2_test", () => {
         pool,
         jwtConfig,
         keygenRequest,
-        TEMP_ENC_SECRET,
+        TEST_ENCRYPTION_SECRET,
         mockLogger,
         customerId,
       );
@@ -832,7 +832,7 @@ describe("keygen_v2_test", () => {
         pool,
         jwtConfig,
         keygenRequest,
-        TEMP_ENC_SECRET,
+        TEST_ENCRYPTION_SECRET,
         mockLogger,
         customerId,
       );
@@ -889,7 +889,7 @@ describe("keygen_v2_test", () => {
         pool,
         jwtConfig,
         keygenRequest,
-        TEMP_ENC_SECRET,
+        TEST_ENCRYPTION_SECRET,
         mockLogger,
         customerId,
       );
@@ -1389,7 +1389,7 @@ describe("keygen_v2_test", () => {
         pool,
         TEST_JWT_CONFIG_ED25519,
         request,
-        TEMP_ENC_SECRET,
+        TEST_ENCRYPTION_SECRET,
         mockLogger,
       );
 
@@ -1415,7 +1415,7 @@ describe("keygen_v2_test", () => {
         pool,
         TEST_JWT_CONFIG_ED25519,
         request,
-        TEMP_ENC_SECRET,
+        TEST_ENCRYPTION_SECRET,
         mockLogger,
       );
 

--- a/backend/oko_api/server/src/api/tss/v2/keygen/index.ts
+++ b/backend/oko_api/server/src/api/tss/v2/keygen/index.ts
@@ -227,7 +227,20 @@ export async function runKeygenV2(
     }
     const activeKSNodes = getActiveKSNodesRes.data;
 
-    // 5. Check keyshare from KS nodes for both curve types
+    // 5. Get key share node meta (SSS threshold + registration threshold)
+    const getKeyshareNodeMetaRes = await getKeyShareNodeMeta(db);
+    if (getKeyshareNodeMetaRes.success === false) {
+      return {
+        success: false,
+        code: "UNKNOWN_ERROR",
+        msg: `getKeyShareNodeMeta error: ${getKeyshareNodeMetaRes.err}`,
+      };
+    }
+    const globalSSSThreshold = getKeyshareNodeMetaRes.data.sss_threshold;
+    const registrationThreshold =
+      getKeyshareNodeMetaRes.data.registration_threshold;
+
+    // 6. Check keyshare from KS nodes for both curve types
     const checkKeyshareV2Res = await checkKeyShareFromKSNodesV2(
       user_identifier,
       {
@@ -236,6 +249,7 @@ export async function runKeygenV2(
       },
       activeKSNodes,
       auth_type,
+      registrationThreshold,
     );
     if (checkKeyshareV2Res.success === false) {
       return checkKeyshareV2Res;
@@ -293,18 +307,7 @@ export async function runKeygenV2(
       ed25519KeyPackageShares.verifying_share,
     ).toString("hex");
 
-    // 8. Get SSS threshold
-    const getKeyshareNodeMetaRes = await getKeyShareNodeMeta(db);
-    if (getKeyshareNodeMetaRes.success === false) {
-      return {
-        success: false,
-        code: "UNKNOWN_ERROR",
-        msg: `getKeyShareNodeMeta error: ${getKeyshareNodeMetaRes.err}`,
-      };
-    }
-    const globalSSSThreshold = getKeyshareNodeMetaRes.data.sss_threshold;
-
-    // 9. Create both wallets in a transaction
+    // 8. Create both wallets in a transaction
     let secp256k1Wallet: Wallet;
     let ed25519Wallet: Wallet;
     const client = await db.connect();

--- a/backend/oko_api/server/src/api/tss/v2/keygen/index.ts
+++ b/backend/oko_api/server/src/api/tss/v2/keygen/index.ts
@@ -602,6 +602,18 @@ export async function runKeygenEd25519(
     }
     const activeUserKSNodes = getNodesByIdsRes.data;
 
+    // Get registration threshold for partial success
+    const getKeyshareNodeMetaRes = await getKeyShareNodeMeta(db);
+    if (getKeyshareNodeMetaRes.success === false) {
+      return {
+        success: false,
+        code: "UNKNOWN_ERROR",
+        msg: `getKeyShareNodeMeta error: ${getKeyshareNodeMetaRes.err}`,
+      };
+    }
+    const registrationThreshold =
+      getKeyshareNodeMetaRes.data.registration_threshold;
+
     const checkKeyshareV2Res = await checkKeyShareFromKSNodesV2(
       user_identifier,
       {
@@ -609,6 +621,7 @@ export async function runKeygenEd25519(
       },
       activeUserKSNodes,
       auth_type,
+      registrationThreshold,
     );
     if (checkKeyshareV2Res.success === false) {
       return checkKeyshareV2Res;
@@ -645,14 +658,7 @@ export async function runKeygenEd25519(
       ed25519KeyPackageShares.verifying_share,
     ).toString("hex");
 
-    const getKeyshareNodeMetaRes = await getKeyShareNodeMeta(db);
-    if (getKeyshareNodeMetaRes.success === false) {
-      return {
-        success: false,
-        code: "UNKNOWN_ERROR",
-        msg: `getKeyShareNodeMeta error: ${getKeyshareNodeMetaRes.err}`,
-      };
-    }
+    // Reuse getKeyshareNodeMetaRes from above (already fetched for registrationThreshold)
     const globalSSSThreshold = getKeyshareNodeMetaRes.data.sss_threshold;
 
     let ed25519Wallet: Wallet;

--- a/backend/oko_api/server/src/api/tss/v2/user/index.ts
+++ b/backend/oko_api/server/src/api/tss/v2/user/index.ts
@@ -432,8 +432,6 @@ export async function updateWalletKSNodesForReshareV2(
         msg: "Unknown server_urls detected",
       };
     }
-    const nodeIds = getKSNodesRes.data.map((n) => n.node_id);
-
     // Get registration threshold for partial success
     const getKeyshareNodeMetaRes = await getKeyShareNodeMeta(db);
     if (getKeyshareNodeMetaRes.success === false) {
@@ -512,7 +510,10 @@ export async function updateWalletKSNodesForReshareV2(
       };
     }
 
-    // Upsert wallet_ks_nodes for both wallets
+    // Upsert wallet_ks_nodes using only verified nodeIds from checkKeyShareFromKSNodesV2
+    const verifiedSecp256k1NodeIds = checkRes.data.secp256k1?.nodeIds ?? [];
+    const verifiedEd25519NodeIds = checkRes.data.ed25519?.nodeIds ?? [];
+
     const client = await db.connect();
     try {
       await client.query("BEGIN");
@@ -520,7 +521,7 @@ export async function updateWalletKSNodesForReshareV2(
       const secp256k1UpsertRes = await upsertWalletKSNodes(
         client,
         secp256k1WalletRes.data.wallet_id,
-        nodeIds,
+        verifiedSecp256k1NodeIds,
       );
       if (!secp256k1UpsertRes.success) {
         throw new Error(`(secp256k1) ${secp256k1UpsertRes.err}`);
@@ -529,7 +530,7 @@ export async function updateWalletKSNodesForReshareV2(
       const ed25519UpsertRes = await upsertWalletKSNodes(
         client,
         ed25519WalletRes.data.wallet_id,
-        nodeIds,
+        verifiedEd25519NodeIds,
       );
       if (!ed25519UpsertRes.success) {
         throw new Error(`(ed25519) ${ed25519UpsertRes.err}`);

--- a/backend/oko_api/server/src/api/tss/v2/user/index.ts
+++ b/backend/oko_api/server/src/api/tss/v2/user/index.ts
@@ -434,12 +434,25 @@ export async function updateWalletKSNodesForReshareV2(
     }
     const nodeIds = getKSNodesRes.data.map((n) => n.node_id);
 
+    // Get registration threshold for partial success
+    const getKeyshareNodeMetaRes = await getKeyShareNodeMeta(db);
+    if (getKeyshareNodeMetaRes.success === false) {
+      return {
+        success: false,
+        code: "UNKNOWN_ERROR",
+        msg: `getKeyShareNodeMeta error: ${getKeyshareNodeMetaRes.err}`,
+      };
+    }
+    const registrationThreshold =
+      getKeyshareNodeMetaRes.data.registration_threshold;
+
     // Check key shares exist on KS nodes
     const checkRes = await checkKeyShareFromKSNodesV2(
       email,
       { secp256k1: secp256k1PublicKey, ed25519: ed25519PublicKey },
       getKSNodesRes.data,
       auth_type,
+      registrationThreshold,
     );
     if (!checkRes.success) {
       return checkRes;

--- a/backend/oko_api/server/src/api/tss/v2/user/index.ts
+++ b/backend/oko_api/server/src/api/tss/v2/user/index.ts
@@ -240,6 +240,8 @@ export async function checkEmailV2(
       };
     }
     const globalThreshold = getKeyshareNodeMetaRes.data.sss_threshold;
+    const registrationThreshold =
+      getKeyshareNodeMetaRes.data.registration_threshold;
     const activeNodesBelowThreshold = activeKSNodes.length < globalThreshold;
 
     // Case 1: User doesn't exist
@@ -251,6 +253,7 @@ export async function checkEmailV2(
           active_nodes_below_threshold: activeNodesBelowThreshold,
           keyshare_node_meta: {
             threshold: globalThreshold,
+            registration_threshold: registrationThreshold,
             nodes: activeKSNodes.map((ksNode) => ({
               name: ksNode.node_name,
               endpoint: ksNode.server_url,
@@ -299,6 +302,7 @@ export async function checkEmailV2(
         secp256k1Wallet,
         activeKSNodes,
         globalThreshold,
+        registrationThreshold,
       );
       if (!secp256k1CheckInfoRes.success) {
         return {
@@ -326,6 +330,7 @@ export async function checkEmailV2(
         ed25519Wallet,
         activeKSNodes,
         globalThreshold,
+        registrationThreshold,
       );
       if (!unifiedCheckInfoRes.success) {
         return {
@@ -352,6 +357,7 @@ export async function checkEmailV2(
         active_nodes_below_threshold: activeNodesBelowThreshold,
         keyshare_node_meta: {
           threshold: globalThreshold,
+          registration_threshold: registrationThreshold,
           nodes: activeKSNodes.map((ksNode) => ({
             name: ksNode.node_name,
             endpoint: ksNode.server_url,
@@ -551,6 +557,7 @@ async function calculateUnifiedCheckInfo(
   ed25519Wallet: Wallet,
   activeKSNodes: KeyShareNode[],
   globalThreshold: number,
+  registrationThreshold: number | null,
 ): Promise<Result<UnifiedCheckInfo, string>> {
   const [secp256k1NodesRes, ed25519NodesRes] = await Promise.all([
     getWalletKSNodesByWalletId(db, secp256k1Wallet.wallet_id),
@@ -624,6 +631,7 @@ async function calculateUnifiedCheckInfo(
     data: {
       keyshare_node_meta: {
         threshold: globalThreshold,
+        registration_threshold: registrationThreshold,
         nodes: unifiedNodes,
       },
       needs_reshare: needsReshare,
@@ -638,6 +646,7 @@ async function calculateSecp256k1OnlyCheckInfo(
   secp256k1Wallet: Wallet,
   activeKSNodes: KeyShareNode[],
   globalThreshold: number,
+  registrationThreshold: number | null,
 ): Promise<Result<UnifiedCheckInfo, string>> {
   const nodesRes = await getWalletKSNodesByWalletId(
     db,
@@ -692,7 +701,11 @@ async function calculateSecp256k1OnlyCheckInfo(
   return {
     success: true,
     data: {
-      keyshare_node_meta: { threshold: globalThreshold, nodes },
+      keyshare_node_meta: {
+        threshold: globalThreshold,
+        registration_threshold: registrationThreshold,
+        nodes,
+      },
       needs_reshare: needsReshare,
       reshare_reasons: needsReshare ? reshare_reasons : undefined,
       active_nodes_below_threshold: activeNodeCount < globalThreshold,

--- a/backend/oko_api/server/src/routes/tss_v1/keygen.test.ts
+++ b/backend/oko_api/server/src/routes/tss_v1/keygen.test.ts
@@ -52,6 +52,25 @@ await jest.unstable_mockModule("@oko-wallet-api/middleware/auth/oauth", () => ({
     mockOauthMiddleware(req, res, next),
 }));
 
+const TEST_CUSTOMER_ID = "test-customer-id";
+
+await jest.unstable_mockModule(
+  "@oko-wallet-api/middleware/auth/api_key_auth",
+  () => ({
+    apiKeyMiddleware: (req: any, res: any, next: any) => {
+      const apiKey = req.headers["x-api-key"];
+      if (!apiKey) {
+        return res.status(401).json({ error: "API key is required" });
+      }
+      res.locals.api_key = {
+        customer_id: TEST_CUSTOMER_ID,
+        is_active: true,
+      };
+      next();
+    },
+  }),
+);
+
 await jest.unstable_mockModule(
   "@oko-wallet-api/middleware/auth/tss_activate",
   () => ({
@@ -100,6 +119,7 @@ describe("keygen_v1_route_test", () => {
   const testEndpoint = "/tss/v1/keygen";
   const validToken = "valid_token";
   const invalidToken = "invalid_token";
+  const validApiKey = "test-api-key";
 
   const testKeygenBody = {
     auth_type: "google",
@@ -110,9 +130,19 @@ describe("keygen_v1_route_test", () => {
   };
 
   describe("keygen", () => {
+    it("should return 401 when no API key is provided", async () => {
+      const response = await request(app)
+        .post(testEndpoint)
+        .send(testKeygenBody);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("API key is required");
+    });
+
     it("should return 401 when no authorization header is provided", async () => {
       const response = await request(app)
         .post(testEndpoint)
+        .set("x-api-key", validApiKey)
         .send(testKeygenBody);
 
       expect(response.status).toBe(401);
@@ -124,6 +154,7 @@ describe("keygen_v1_route_test", () => {
     it("should return 401 when invalid token is provided", async () => {
       const response = await request(app)
         .post(testEndpoint)
+        .set("x-api-key", validApiKey)
         .set("Authorization", `Bearer ${invalidToken}`)
         .send(testKeygenBody);
 
@@ -149,6 +180,7 @@ describe("keygen_v1_route_test", () => {
 
       const response = await request(app)
         .post(testEndpoint)
+        .set("x-api-key", validApiKey)
         .set("Authorization", `Bearer ${validToken}`)
         .send(testKeygenBody);
 
@@ -172,6 +204,8 @@ describe("keygen_v1_route_test", () => {
           name: "Test User",
         },
         TEMP_ENC_SECRET,
+        expect.anything(),
+        TEST_CUSTOMER_ID,
       );
     });
 
@@ -186,6 +220,7 @@ describe("keygen_v1_route_test", () => {
 
       const response = await request(app)
         .post(testEndpoint)
+        .set("x-api-key", validApiKey)
         .set("Authorization", `Bearer ${validToken}`)
         .send(testKeygenBody);
 
@@ -210,6 +245,8 @@ describe("keygen_v1_route_test", () => {
           name: "Test User",
         },
         TEMP_ENC_SECRET,
+        expect.anything(),
+        TEST_CUSTOMER_ID,
       );
     });
   });

--- a/backend/oko_api/server/src/routes/tss_v1/tss_session.test.ts
+++ b/backend/oko_api/server/src/routes/tss_v1/tss_session.test.ts
@@ -62,6 +62,7 @@ describe("tss_session_route_test", () => {
 
     await insertKeyShareNodeMeta(pool, {
       sss_threshold: SSS_THRESHOLD,
+      registration_threshold: null,
     });
 
     const createUserRes = await createUser(pool, "test@example.com", "google");

--- a/backend/oko_api/server/src/routes/tss_v1/user.test.ts
+++ b/backend/oko_api/server/src/routes/tss_v1/user.test.ts
@@ -55,6 +55,25 @@ await jest.unstable_mockModule("@oko-wallet-api/middleware/auth/oauth", () => ({
     mockOauthMiddleware(req, res, next),
 }));
 
+const TEST_CUSTOMER_ID = "test-customer-id";
+
+await jest.unstable_mockModule(
+  "@oko-wallet-api/middleware/auth/api_key_auth",
+  () => ({
+    apiKeyMiddleware: (req: any, res: any, next: any) => {
+      const apiKey = req.headers["x-api-key"];
+      if (!apiKey) {
+        return res.status(401).json({ error: "API key is required" });
+      }
+      res.locals.api_key = {
+        customer_id: TEST_CUSTOMER_ID,
+        is_active: true,
+      };
+      next();
+    },
+  }),
+);
+
 await jest.unstable_mockModule(
   "@oko-wallet-api/middleware/auth/tss_activate",
   () => ({
@@ -263,10 +282,21 @@ describe("user_route_test", () => {
     const testEndpoint = "/tss/v1/user/signin";
     const validToken = "valid_token";
     const invalidToken = "invalid_token";
+    const validApiKey = "test-api-key";
+
+    it("should return 401 when no API key is provided", async () => {
+      const response = await request(app)
+        .post(testEndpoint)
+        .send({ auth_type: "google" });
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("API key is required");
+    });
 
     it("should return 401 when no authorization header is provided", async () => {
       const response = await request(app)
         .post(testEndpoint)
+        .set("x-api-key", validApiKey)
         .send({ auth_type: "google" });
 
       expect(response.status).toBe(401);
@@ -278,6 +308,7 @@ describe("user_route_test", () => {
     it("should return 401 when invalid token is provided", async () => {
       const response = await request(app)
         .post(testEndpoint)
+        .set("x-api-key", validApiKey)
         .set("Authorization", `Bearer ${invalidToken}`)
         .send({ auth_type: "google" });
 
@@ -288,6 +319,7 @@ describe("user_route_test", () => {
     it("should return 404 when user does not exist", async () => {
       const response = await request(app)
         .post(testEndpoint)
+        .set("x-api-key", validApiKey)
         .set("Authorization", `Bearer ${validToken}`)
         .send({ auth_type: "google" });
 
@@ -309,6 +341,7 @@ describe("user_route_test", () => {
 
       const response = await request(app)
         .post(testEndpoint)
+        .set("x-api-key", validApiKey)
         .set("Authorization", `Bearer ${validToken}`)
         .send({ auth_type: "google" });
 
@@ -351,6 +384,7 @@ describe("user_route_test", () => {
 
       const response = await request(app)
         .post(testEndpoint)
+        .set("x-api-key", validApiKey)
         .set("Authorization", `Bearer ${validToken}`)
         .send({ auth_type: "google" });
 
@@ -384,6 +418,7 @@ describe("user_route_test", () => {
 
       const response = await request(app)
         .post(testEndpoint)
+        .set("x-api-key", validApiKey)
         .set("Authorization", `Bearer ${validToken}`)
         .send({ auth_type: "google" });
 

--- a/backend/oko_api/server/src/routes/tss_v1/user.test.ts
+++ b/backend/oko_api/server/src/routes/tss_v1/user.test.ts
@@ -119,6 +119,7 @@ describe("user_route_test", () => {
     jest.clearAllMocks();
     await insertKeyShareNodeMeta(pool, {
       sss_threshold: SSS_THRESHOLD,
+      registration_threshold: null,
     });
   });
 

--- a/backend/oko_api/server/src/routes/tss_v2/keygen_registration_threshold.test.ts
+++ b/backend/oko_api/server/src/routes/tss_v2/keygen_registration_threshold.test.ts
@@ -13,8 +13,8 @@ import type { Pool } from "pg";
 import request from "supertest";
 
 import { TEST_CUSTOMER } from "@oko-wallet-api/api/tss/tests";
-import { TEMP_ENC_SECRET } from "@oko-wallet-api/api/tss/utils";
 import { testPgConfig } from "@oko-wallet-api/database/test_config";
+import { TEST_ENCRYPTION_SECRET } from "@oko-wallet-api/testing/constants";
 import { resetPgDatabase } from "@oko-wallet-api/testing/database";
 
 // ── Mocks ───────────────────────────────────────────────────────────────
@@ -122,7 +122,7 @@ describe("keygen_v2_registration_threshold_e2e", () => {
     app = makeApp({
       JWT_SECRET: "test-jwt-secret",
       JWT_EXPIRES_IN: "1h",
-      ENCRYPTION_SECRET: TEMP_ENC_SECRET,
+      ENCRYPTION_SECRET: TEST_ENCRYPTION_SECRET,
     });
     app.locals.db = pool;
   });

--- a/backend/oko_api/server/src/routes/tss_v2/keygen_registration_threshold.test.ts
+++ b/backend/oko_api/server/src/routes/tss_v2/keygen_registration_threshold.test.ts
@@ -1,0 +1,324 @@
+import { jest } from "@jest/globals";
+import { napiRunKeygenClientCentralized } from "@oko-wallet/cait-sith-keplr-addon/addon";
+import { insertCustomer } from "@oko-wallet/oko-pg-interface/customers";
+import { insertKeyShareNodeMeta } from "@oko-wallet/oko-pg-interface/key_share_node_meta";
+import {
+  getWalletKSNodesByWalletId,
+  insertKSNode,
+} from "@oko-wallet/oko-pg-interface/ks_nodes";
+import { createPgConn } from "@oko-wallet/postgres-lib";
+import { Participant } from "@oko-wallet/tecdsa-interface";
+import { runKeygenCentralizedEd25519 } from "@oko-wallet/teddsa-addon/src/server";
+import type { Pool } from "pg";
+import request from "supertest";
+
+import { TEST_CUSTOMER } from "@oko-wallet-api/api/tss/tests";
+import { TEMP_ENC_SECRET } from "@oko-wallet-api/api/tss/utils";
+import { testPgConfig } from "@oko-wallet-api/database/test_config";
+import { resetPgDatabase } from "@oko-wallet-api/testing/database";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+const mockCheckKeyShareFromKSNodesV2 = jest.fn() as jest.Mock;
+
+const mockCheckKeyShareFromKSNodes = jest.fn();
+
+await jest.unstable_mockModule("@oko-wallet-api/api/tss/ks_node", () => ({
+  checkKeyShareFromKSNodes: mockCheckKeyShareFromKSNodes,
+  checkKeyShareFromKSNodesV2: mockCheckKeyShareFromKSNodesV2,
+}));
+
+const TEST_CUSTOMER_ID = "test-customer-id";
+
+await jest.unstable_mockModule(
+  "@oko-wallet-api/middleware/auth/api_key_auth",
+  () => ({
+    apiKeyMiddleware: (_req: any, res: any, next: any) => {
+      res.locals.api_key = {
+        customer_id: TEST_CUSTOMER_ID,
+        is_active: true,
+      };
+      next();
+    },
+  }),
+);
+
+await jest.unstable_mockModule("@oko-wallet-api/middleware/auth/oauth", () => ({
+  oauthMiddleware: (_req: any, res: any, next: any) => {
+    res.locals.oauth_user = {
+      type: "google",
+      user_identifier: "e2e-test@example.com",
+      email: "e2e-test@example.com",
+      name: "E2E Test User",
+    };
+    next();
+  },
+}));
+
+await jest.unstable_mockModule(
+  "@oko-wallet-api/middleware/auth/tss_activate",
+  () => ({
+    tssActivateMiddleware: (_req: any, _res: any, next: any) => next(),
+  }),
+);
+
+await jest.unstable_mockModule(
+  "@oko-wallet-api/middleware/commit_reveal",
+  () => ({
+    commitRevealMiddleware: () => (_req: any, _res: any, next: any) => next(),
+  }),
+);
+
+const { makeApp } = await import("@oko-wallet-api/testing/app");
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const SSS_THRESHOLD = 2;
+const TEST_SEED_SHARE = "a".repeat(64) + "b".repeat(64);
+
+function buildKeygenBody() {
+  const secp256k1KeygenResult = napiRunKeygenClientCentralized();
+  const ed25519KeygenResult = runKeygenCentralizedEd25519();
+  const keygen2Secp = secp256k1KeygenResult.keygen_outputs[Participant.P1];
+  const keygen2Ed = ed25519KeygenResult.keygen_outputs[Participant.P1];
+
+  return {
+    auth_type: "google",
+    keygen_2_secp256k1: {
+      public_key: keygen2Secp.public_key,
+      private_share: keygen2Secp.private_share,
+    },
+    keygen_2_ed25519: {
+      key_package: keygen2Ed.key_package,
+      public_key_package: keygen2Ed.public_key_package,
+      identifier: [...keygen2Ed.identifier],
+      public_key: [...ed25519KeygenResult.public_key],
+    },
+    ed25519_seed_share: TEST_SEED_SHARE,
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("keygen_v2_registration_threshold_e2e", () => {
+  let app: any;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    const config = testPgConfig;
+    const createPostgresRes = await createPgConn({
+      database: config.database,
+      host: config.host,
+      password: config.password,
+      user: config.user,
+      port: config.port,
+      ssl: config.ssl,
+    });
+    if (createPostgresRes.success === false) {
+      throw new Error("Failed to create postgres database");
+    }
+    pool = createPostgresRes.data;
+
+    app = makeApp({
+      JWT_SECRET: "test-jwt-secret",
+      JWT_EXPIRES_IN: "1h",
+      ENCRYPTION_SECRET: TEMP_ENC_SECRET,
+    });
+    app.locals.db = pool;
+  });
+
+  beforeEach(async () => {
+    await resetPgDatabase(pool);
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  async function setUpKSNodes(count: number): Promise<string[]> {
+    const ids: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const res = await insertKSNode(
+        pool,
+        `ksNode${i + 1}`,
+        `http://test.com/ksNode${i + 1}`,
+      );
+      if (res.success === false) {
+        throw new Error("Failed to create ks node");
+      }
+      ids.push(res.data.node_id);
+    }
+    return ids;
+  }
+
+  async function createTestCustomer(): Promise<string> {
+    const res = await insertCustomer(pool, TEST_CUSTOMER);
+    if (res.success === false) {
+      throw new Error("Failed to insert customer");
+    }
+    return res.data.customer_id;
+  }
+
+  describe("partial success (registration_threshold=2)", () => {
+    it("should return 200 and register only successful nodes", async () => {
+      // Setup: threshold=2, 3 KS nodes
+      await insertKeyShareNodeMeta(pool, {
+        sss_threshold: SSS_THRESHOLD,
+        registration_threshold: 2,
+      });
+      const ksNodeIds = await setUpKSNodes(3);
+      await createTestCustomer();
+
+      // Mock: only first 2 nodes succeed
+      const successNodeIds = [ksNodeIds[0], ksNodeIds[1]];
+      (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+        success: true,
+        data: {
+          secp256k1: { nodeIds: successNodeIds },
+          ed25519: { nodeIds: successNodeIds },
+        },
+      });
+
+      const body = buildKeygenBody();
+
+      const response = await request(app)
+        .post("/tss/v2/keygen")
+        .send(body)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+      expect(response.body.data.user.wallet_id_secp256k1).toBeDefined();
+      expect(response.body.data.user.wallet_id_ed25519).toBeDefined();
+      expect(response.body.data.token).toBeDefined();
+
+      // Verify only 2 nodes registered for each wallet
+      const secp256k1Res = await getWalletKSNodesByWalletId(
+        pool,
+        response.body.data.user.wallet_id_secp256k1,
+      );
+      if (secp256k1Res.success === false) {
+        throw new Error("Failed to get wallet ks nodes");
+      }
+      expect(secp256k1Res.data).toHaveLength(2);
+      expect(secp256k1Res.data.map((n) => n.node_id).sort()).toEqual(
+        successNodeIds.sort(),
+      );
+
+      const ed25519Res = await getWalletKSNodesByWalletId(
+        pool,
+        response.body.data.user.wallet_id_ed25519,
+      );
+      if (ed25519Res.success === false) {
+        throw new Error("Failed to get wallet ks nodes");
+      }
+      expect(ed25519Res.data).toHaveLength(2);
+      expect(ed25519Res.data.map((n) => n.node_id).sort()).toEqual(
+        successNodeIds.sort(),
+      );
+
+      // Verify registrationThreshold was passed to checkKeyShareFromKSNodesV2
+      expect(mockCheckKeyShareFromKSNodesV2).toHaveBeenCalledTimes(1);
+      const callArgs = mockCheckKeyShareFromKSNodesV2.mock.calls[0];
+      expect(callArgs[4]).toBe(2);
+    });
+  });
+
+  describe("threshold not met (registration_threshold=2, only 1 success)", () => {
+    it("should return error when checkKeyShareFromKSNodesV2 fails", async () => {
+      await insertKeyShareNodeMeta(pool, {
+        sss_threshold: SSS_THRESHOLD,
+        registration_threshold: 2,
+      });
+      await setUpKSNodes(3);
+      await createTestCustomer();
+
+      // Mock: checkKeyShareFromKSNodesV2 returns failure (threshold not met)
+      (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+        success: false,
+        code: "KEYSHARE_NODE_INSUFFICIENT",
+        msg: "secp256k1: 1/3 nodes succeeded (need 2)",
+      });
+
+      const body = buildKeygenBody();
+
+      const response = await request(app)
+        .post("/tss/v2/keygen")
+        .send(body)
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.code).toBe("KEYSHARE_NODE_INSUFFICIENT");
+      expect(response.body.msg).toContain("1/3 nodes succeeded");
+    });
+  });
+
+  describe("null threshold fallback (all-or-nothing)", () => {
+    it("should use all-or-nothing mode and return all nodeIds", async () => {
+      await insertKeyShareNodeMeta(pool, {
+        sss_threshold: SSS_THRESHOLD,
+        registration_threshold: null,
+      });
+      const ksNodeIds = await setUpKSNodes(2);
+      await createTestCustomer();
+
+      // Mock: all nodes succeed
+      (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+        success: true,
+        data: {
+          secp256k1: { nodeIds: ksNodeIds },
+          ed25519: { nodeIds: ksNodeIds },
+        },
+      });
+
+      const body = buildKeygenBody();
+
+      const response = await request(app)
+        .post("/tss/v2/keygen")
+        .send(body)
+        .expect(200);
+
+      expect(response.body.success).toBe(true);
+
+      // Verify all nodes registered
+      const secp256k1Res = await getWalletKSNodesByWalletId(
+        pool,
+        response.body.data.user.wallet_id_secp256k1,
+      );
+      if (secp256k1Res.success === false) {
+        throw new Error("Failed to get wallet ks nodes");
+      }
+      expect(secp256k1Res.data).toHaveLength(2);
+
+      // Verify registrationThreshold was passed as null
+      expect(mockCheckKeyShareFromKSNodesV2).toHaveBeenCalledTimes(1);
+      const callArgs = mockCheckKeyShareFromKSNodesV2.mock.calls[0];
+      expect(callArgs[4]).toBeNull();
+    });
+
+    it("should fail when any node fails in all-or-nothing mode", async () => {
+      await insertKeyShareNodeMeta(pool, {
+        sss_threshold: SSS_THRESHOLD,
+        registration_threshold: null,
+      });
+      await setUpKSNodes(2);
+      await createTestCustomer();
+
+      (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+        success: false,
+        code: "KEYSHARE_NODE_INSUFFICIENT",
+        msg: "name: ksNode2, err: keyshare does not exist",
+      });
+
+      const body = buildKeygenBody();
+
+      const response = await request(app)
+        .post("/tss/v2/keygen")
+        .send(body)
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.code).toBe("KEYSHARE_NODE_INSUFFICIENT");
+    });
+  });
+});

--- a/backend/oko_api/server/src/routes/tss_v2/registration_reshare_scenario.test.ts
+++ b/backend/oko_api/server/src/routes/tss_v2/registration_reshare_scenario.test.ts
@@ -1,0 +1,439 @@
+import { jest } from "@jest/globals";
+import { napiRunKeygenClientCentralized } from "@oko-wallet/cait-sith-keplr-addon/addon";
+import { insertCustomer } from "@oko-wallet/oko-pg-interface/customers";
+import { insertKeyShareNodeMeta } from "@oko-wallet/oko-pg-interface/key_share_node_meta";
+import {
+  getWalletKSNodesByWalletId,
+  insertKSNode,
+} from "@oko-wallet/oko-pg-interface/ks_nodes";
+import { createPgConn } from "@oko-wallet/postgres-lib";
+import { Participant } from "@oko-wallet/tecdsa-interface";
+import { runKeygenCentralizedEd25519 } from "@oko-wallet/teddsa-addon/src/server";
+import type { Pool } from "pg";
+import request from "supertest";
+
+import { TEST_CUSTOMER } from "@oko-wallet-api/api/tss/tests";
+import { TEMP_ENC_SECRET } from "@oko-wallet-api/api/tss/utils";
+import { testPgConfig } from "@oko-wallet-api/database/test_config";
+import { resetPgDatabase } from "@oko-wallet-api/testing/database";
+
+// ── Mocks ───────────────────────────────────────────────────────────────
+
+const mockCheckKeyShareFromKSNodesV2 = jest.fn() as jest.Mock;
+const mockCheckKeyShareFromKSNodes = jest.fn();
+
+await jest.unstable_mockModule("@oko-wallet-api/api/tss/ks_node", () => ({
+  checkKeyShareFromKSNodes: mockCheckKeyShareFromKSNodes,
+  checkKeyShareFromKSNodesV2: mockCheckKeyShareFromKSNodesV2,
+}));
+
+const TEST_EMAIL = "scenario-test@example.com";
+const TEST_CUSTOMER_ID = "test-customer-id";
+
+await jest.unstable_mockModule(
+  "@oko-wallet-api/middleware/auth/api_key_auth",
+  () => ({
+    apiKeyMiddleware: (_req: any, res: any, next: any) => {
+      res.locals.api_key = {
+        customer_id: TEST_CUSTOMER_ID,
+        is_active: true,
+      };
+      next();
+    },
+  }),
+);
+
+await jest.unstable_mockModule("@oko-wallet-api/middleware/auth/oauth", () => ({
+  oauthMiddleware: (_req: any, res: any, next: any) => {
+    res.locals.oauth_user = {
+      type: "google",
+      user_identifier: TEST_EMAIL,
+      email: TEST_EMAIL,
+      name: "Scenario Test User",
+    };
+    next();
+  },
+}));
+
+await jest.unstable_mockModule(
+  "@oko-wallet-api/middleware/auth/tss_activate",
+  () => ({
+    tssActivateMiddleware: (_req: any, _res: any, next: any) => next(),
+  }),
+);
+
+await jest.unstable_mockModule(
+  "@oko-wallet-api/middleware/commit_reveal",
+  () => ({
+    commitRevealMiddleware: () => (_req: any, _res: any, next: any) => next(),
+  }),
+);
+
+const { makeApp } = await import("@oko-wallet-api/testing/app");
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+const SSS_THRESHOLD = 2;
+const TEST_SEED_SHARE = "a".repeat(64) + "b".repeat(64);
+
+function buildKeygenBody() {
+  const secp256k1KeygenResult = napiRunKeygenClientCentralized();
+  const ed25519KeygenResult = runKeygenCentralizedEd25519();
+  const keygen2Secp = secp256k1KeygenResult.keygen_outputs[Participant.P1];
+  const keygen2Ed = ed25519KeygenResult.keygen_outputs[Participant.P1];
+
+  return {
+    body: {
+      auth_type: "google",
+      keygen_2_secp256k1: {
+        public_key: keygen2Secp.public_key,
+        private_share: keygen2Secp.private_share,
+      },
+      keygen_2_ed25519: {
+        key_package: keygen2Ed.key_package,
+        public_key_package: keygen2Ed.public_key_package,
+        identifier: [...keygen2Ed.identifier],
+        public_key: [...ed25519KeygenResult.public_key],
+      },
+      ed25519_seed_share: TEST_SEED_SHARE,
+    },
+    secp256k1PublicKey: keygen2Secp.public_key,
+    ed25519PublicKey: Buffer.from(ed25519KeygenResult.public_key).toString(
+      "hex",
+    ),
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe("registration + reshare scenario e2e", () => {
+  let app: any;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    const config = testPgConfig;
+    const createPostgresRes = await createPgConn({
+      database: config.database,
+      host: config.host,
+      password: config.password,
+      user: config.user,
+      port: config.port,
+      ssl: config.ssl,
+    });
+    if (createPostgresRes.success === false) {
+      throw new Error("Failed to create postgres database");
+    }
+    pool = createPostgresRes.data;
+
+    app = makeApp({
+      JWT_SECRET: "test-jwt-secret",
+      JWT_EXPIRES_IN: "1h",
+      ENCRYPTION_SECRET: TEMP_ENC_SECRET,
+    });
+    app.locals.db = pool;
+  });
+
+  beforeEach(async () => {
+    await resetPgDatabase(pool);
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  async function setUpKSNodes(count: number): Promise<string[]> {
+    const ids: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const res = await insertKSNode(
+        pool,
+        `ksNode${i + 1}`,
+        `http://test.com/ksNode${i + 1}`,
+      );
+      if (res.success === false) {
+        throw new Error("Failed to create ks node");
+      }
+      ids.push(res.data.node_id);
+    }
+    return ids;
+  }
+
+  async function createTestCustomer(): Promise<string> {
+    const res = await insertCustomer(pool, TEST_CUSTOMER);
+    if (res.success === false) {
+      throw new Error("Failed to insert customer");
+    }
+    return res.data.customer_id;
+  }
+
+  function getWalletKSNodeIds(walletId: string) {
+    return getWalletKSNodesByWalletId(pool, walletId).then((res) => {
+      if (res.success === false) {
+        throw new Error("Failed to get wallet ks nodes");
+      }
+      return res.data.map((n) => n.node_id).sort();
+    });
+  }
+
+  // ── Scenario 1 ──────────────────────────────────────────────────────
+
+  it("signup(2/3) → reshare(node 3 still down) → partial reshare, wallet_ks_nodes stays 2", async () => {
+    // Setup
+    await insertKeyShareNodeMeta(pool, {
+      sss_threshold: SSS_THRESHOLD,
+      registration_threshold: 2,
+    });
+    const ksNodeIds = await setUpKSNodes(3);
+    await createTestCustomer();
+
+    // Step 1: Keygen — node 3 down, only 1,2 succeed
+    const successNodeIds = [ksNodeIds[0], ksNodeIds[1]];
+    (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+      success: true,
+      data: {
+        secp256k1: { nodeIds: successNodeIds },
+        ed25519: { nodeIds: successNodeIds },
+      },
+    });
+
+    const {
+      body: keygenBody,
+      secp256k1PublicKey,
+      ed25519PublicKey,
+    } = buildKeygenBody();
+    const keygenRes = await request(app)
+      .post("/tss/v2/keygen")
+      .send(keygenBody)
+      .expect(200);
+    expect(keygenRes.body.success).toBe(true);
+    const walletIdSecp = keygenRes.body.data.user.wallet_id_secp256k1;
+    const walletIdEd = keygenRes.body.data.user.wallet_id_ed25519;
+
+    // Verify: 2 nodes registered
+    expect(await getWalletKSNodeIds(walletIdSecp)).toEqual(
+      successNodeIds.sort(),
+    );
+    expect(await getWalletKSNodeIds(walletIdEd)).toEqual(successNodeIds.sort());
+
+    // Step 2: Reshare — node 3 still down, mock returns only 1,2
+    (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+      success: true,
+      data: {
+        secp256k1: { nodeIds: successNodeIds },
+        ed25519: { nodeIds: successNodeIds },
+      },
+    });
+
+    const reshareRes = await request(app)
+      .post("/tss/v2/user/reshare")
+      .send({
+        auth_type: "google",
+        secp256k1_public_key: secp256k1PublicKey,
+        ed25519_public_key: ed25519PublicKey,
+        reshared_key_shares: successNodeIds.map((_, i) => ({
+          name: `ksNode${i + 1}`,
+          endpoint: `http://test.com/ksNode${i + 1}`,
+        })),
+      })
+      .expect(200);
+
+    expect(reshareRes.body.success).toBe(true);
+
+    // Verify: still 2 nodes
+    expect(await getWalletKSNodeIds(walletIdSecp)).toEqual(
+      successNodeIds.sort(),
+    );
+    expect(await getWalletKSNodeIds(walletIdEd)).toEqual(successNodeIds.sort());
+  });
+
+  // ── Scenario 2 ──────────────────────────────────────────────────────
+
+  it("signup(2/3) → node 3 recovers → reshare(all 3) → wallet_ks_nodes expands to 3", async () => {
+    // Setup
+    await insertKeyShareNodeMeta(pool, {
+      sss_threshold: SSS_THRESHOLD,
+      registration_threshold: 2,
+    });
+    const ksNodeIds = await setUpKSNodes(3);
+    await createTestCustomer();
+
+    // Step 1: Keygen — node 3 down, only 1,2 succeed
+    const partialNodeIds = [ksNodeIds[0], ksNodeIds[1]];
+    (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+      success: true,
+      data: {
+        secp256k1: { nodeIds: partialNodeIds },
+        ed25519: { nodeIds: partialNodeIds },
+      },
+    });
+
+    const {
+      body: keygenBody,
+      secp256k1PublicKey,
+      ed25519PublicKey,
+    } = buildKeygenBody();
+    const keygenRes = await request(app)
+      .post("/tss/v2/keygen")
+      .send(keygenBody)
+      .expect(200);
+
+    const walletIdSecp = keygenRes.body.data.user.wallet_id_secp256k1;
+    const walletIdEd = keygenRes.body.data.user.wallet_id_ed25519;
+
+    // Verify: 2 nodes after signup
+    expect(await getWalletKSNodeIds(walletIdSecp)).toEqual(
+      partialNodeIds.sort(),
+    );
+
+    // Step 2: Node 3 recovers → reshare with all 3 nodes
+    (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+      success: true,
+      data: {
+        secp256k1: { nodeIds: ksNodeIds },
+        ed25519: { nodeIds: ksNodeIds },
+      },
+    });
+
+    const reshareRes = await request(app)
+      .post("/tss/v2/user/reshare")
+      .send({
+        auth_type: "google",
+        secp256k1_public_key: secp256k1PublicKey,
+        ed25519_public_key: ed25519PublicKey,
+        reshared_key_shares: ksNodeIds.map((_, i) => ({
+          name: `ksNode${i + 1}`,
+          endpoint: `http://test.com/ksNode${i + 1}`,
+        })),
+      })
+      .expect(200);
+
+    expect(reshareRes.body.success).toBe(true);
+
+    // Verify: expanded to 3 nodes
+    expect(await getWalletKSNodeIds(walletIdSecp)).toEqual(ksNodeIds.sort());
+    expect(await getWalletKSNodeIds(walletIdEd)).toEqual(ksNodeIds.sort());
+  });
+
+  // ── Scenario 3 ──────────────────────────────────────────────────────
+
+  it("signup(3/3) → node 3 data loss → reshare partial(1,2 only) → login succeeds", async () => {
+    // Setup
+    await insertKeyShareNodeMeta(pool, {
+      sss_threshold: SSS_THRESHOLD,
+      registration_threshold: 2,
+    });
+    const ksNodeIds = await setUpKSNodes(3);
+    await createTestCustomer();
+
+    // Step 1: Keygen — all 3 succeed
+    (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+      success: true,
+      data: {
+        secp256k1: { nodeIds: ksNodeIds },
+        ed25519: { nodeIds: ksNodeIds },
+      },
+    });
+
+    const {
+      body: keygenBody,
+      secp256k1PublicKey,
+      ed25519PublicKey,
+    } = buildKeygenBody();
+    const keygenRes = await request(app)
+      .post("/tss/v2/keygen")
+      .send(keygenBody)
+      .expect(200);
+
+    const walletIdSecp = keygenRes.body.data.user.wallet_id_secp256k1;
+    const walletIdEd = keygenRes.body.data.user.wallet_id_ed25519;
+
+    // Verify: all 3 nodes after signup
+    expect(await getWalletKSNodeIds(walletIdSecp)).toEqual(ksNodeIds.sort());
+
+    // Step 2: Node 3 has data loss, reshare sends to 1,2 only
+    const reshareNodeIds = [ksNodeIds[0], ksNodeIds[1]];
+    (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+      success: true,
+      data: {
+        secp256k1: { nodeIds: reshareNodeIds },
+        ed25519: { nodeIds: reshareNodeIds },
+      },
+    });
+
+    const reshareRes = await request(app)
+      .post("/tss/v2/user/reshare")
+      .send({
+        auth_type: "google",
+        secp256k1_public_key: secp256k1PublicKey,
+        ed25519_public_key: ed25519PublicKey,
+        reshared_key_shares: reshareNodeIds.map((_, i) => ({
+          name: `ksNode${i + 1}`,
+          endpoint: `http://test.com/ksNode${i + 1}`,
+        })),
+      })
+      .expect(200);
+
+    expect(reshareRes.body.success).toBe(true);
+
+    // Verify: wallet_ks_nodes still has all 3 (upsert doesn't remove existing)
+    // Nodes 1,2 are upserted (refreshed), node 3 keeps its existing record
+    const secpNodes = await getWalletKSNodeIds(walletIdSecp);
+    expect(secpNodes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // ── Scenario 4 ──────────────────────────────────────────────────────
+
+  it("null threshold → reshare all-or-nothing: fails when checkKeyShare fails", async () => {
+    // Setup: null registration_threshold → all-or-nothing
+    await insertKeyShareNodeMeta(pool, {
+      sss_threshold: SSS_THRESHOLD,
+      registration_threshold: null,
+    });
+    const ksNodeIds = await setUpKSNodes(2);
+    await createTestCustomer();
+
+    // Step 1: Keygen — all succeed
+    (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+      success: true,
+      data: {
+        secp256k1: { nodeIds: ksNodeIds },
+        ed25519: { nodeIds: ksNodeIds },
+      },
+    });
+
+    const {
+      body: keygenBody,
+      secp256k1PublicKey,
+      ed25519PublicKey,
+    } = buildKeygenBody();
+    const keygenRes = await request(app)
+      .post("/tss/v2/keygen")
+      .send(keygenBody)
+      .expect(200);
+
+    expect(keygenRes.body.success).toBe(true);
+
+    // Step 2: Reshare — checkKeyShareFromKSNodesV2 fails (one node down)
+    (mockCheckKeyShareFromKSNodesV2 as any).mockResolvedValue({
+      success: false,
+      code: "KEYSHARE_NODE_INSUFFICIENT",
+      msg: "name: ksNode2, err: keyshare does not exist",
+    });
+
+    const reshareRes = await request(app)
+      .post("/tss/v2/user/reshare")
+      .send({
+        auth_type: "google",
+        secp256k1_public_key: secp256k1PublicKey,
+        ed25519_public_key: ed25519PublicKey,
+        reshared_key_shares: ksNodeIds.map((_, i) => ({
+          name: `ksNode${i + 1}`,
+          endpoint: `http://test.com/ksNode${i + 1}`,
+        })),
+      })
+      .expect(400);
+
+    expect(reshareRes.body.success).toBe(false);
+    expect(reshareRes.body.code).toBe("KEYSHARE_NODE_INSUFFICIENT");
+  });
+});

--- a/backend/oko_api/server/src/routes/tss_v2/registration_reshare_scenario.test.ts
+++ b/backend/oko_api/server/src/routes/tss_v2/registration_reshare_scenario.test.ts
@@ -345,7 +345,6 @@ describe("registration + reshare scenario e2e", () => {
       .expect(200);
 
     const walletIdSecp = keygenRes.body.data.user.wallet_id_secp256k1;
-    const walletIdEd = keygenRes.body.data.user.wallet_id_ed25519;
 
     // Verify: all 3 nodes after signup
     expect(await getWalletKSNodeIds(walletIdSecp)).toEqual(ksNodeIds.sort());

--- a/backend/oko_api/server/src/routes/tss_v2/registration_reshare_scenario.test.ts
+++ b/backend/oko_api/server/src/routes/tss_v2/registration_reshare_scenario.test.ts
@@ -13,8 +13,8 @@ import type { Pool } from "pg";
 import request from "supertest";
 
 import { TEST_CUSTOMER } from "@oko-wallet-api/api/tss/tests";
-import { TEMP_ENC_SECRET } from "@oko-wallet-api/api/tss/utils";
 import { testPgConfig } from "@oko-wallet-api/database/test_config";
+import { TEST_ENCRYPTION_SECRET } from "@oko-wallet-api/testing/constants";
 import { resetPgDatabase } from "@oko-wallet-api/testing/database";
 
 // ── Mocks ───────────────────────────────────────────────────────────────
@@ -128,7 +128,7 @@ describe("registration + reshare scenario e2e", () => {
     app = makeApp({
       JWT_SECRET: "test-jwt-secret",
       JWT_EXPIRES_IN: "1h",
-      ENCRYPTION_SECRET: TEMP_ENC_SECRET,
+      ENCRYPTION_SECRET: TEST_ENCRYPTION_SECRET,
     });
     app.locals.db = pool;
   });

--- a/backend/oko_api/server/src/routes/tss_v2/user_signin_silently.ts
+++ b/backend/oko_api/server/src/routes/tss_v2/user_signin_silently.ts
@@ -91,8 +91,6 @@ export async function userSignInSilentlyV2(
   // Try V2 token first
   const v2Result = verifyUserTokenV2({ token, jwt_config: jwtConfig });
 
-  console.log("v2Result", v2Result);
-
   if (v2Result.success) {
     // V2 token is still valid
     res.status(200).json({ success: true, data: { token: null } });

--- a/backend/oko_api/server/src/testing/app.ts
+++ b/backend/oko_api/server/src/testing/app.ts
@@ -4,6 +4,7 @@ import helmet from "helmet";
 import morgan from "morgan";
 import winston from "winston";
 
+import { makeLogRouterV1 } from "@oko-wallet-api/routes/log_v1";
 import { makeTSSRouterV1 } from "@oko-wallet-api/routes/tss_v1";
 import { makeTSSRouterV2 } from "@oko-wallet-api/routes/tss_v2";
 
@@ -43,6 +44,7 @@ export function makeApp(env: TestEnvs) {
 
   app.use("/tss/v1", makeTSSRouterV1());
   app.use("/tss/v2", makeTSSRouterV2());
+  app.use("/log/v1", makeLogRouterV1());
 
   const e = env as any;
   app.locals.jwt_secret = e.JWT_SECRET;

--- a/backend/oko_pg_interface/migrations/20260316000000_add_registration_threshold.ts
+++ b/backend/oko_pg_interface/migrations/20260316000000_add_registration_threshold.ts
@@ -12,12 +12,33 @@ export async function up(knex: Knex): Promise<void> {
         table.specificType("registration_threshold", "smallint");
       });
   }
+
+  // Add CHECK constraint: registration_threshold must be >= sss_threshold
+  await knex.raw(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'check_registration_threshold_gte_sss'
+      ) THEN
+        ALTER TABLE public.key_share_node_meta
+        ADD CONSTRAINT check_registration_threshold_gte_sss
+        CHECK (registration_threshold IS NULL OR registration_threshold >= sss_threshold);
+      END IF;
+    END $$;
+  `);
 }
 
 export async function down(knex: Knex): Promise<void> {
   const hasColumn = await knex.schema
     .withSchema("public")
     .hasColumn("key_share_node_meta", "registration_threshold");
+
+  // Drop CHECK constraint first
+  await knex.raw(`
+    ALTER TABLE public.key_share_node_meta
+    DROP CONSTRAINT IF EXISTS check_registration_threshold_gte_sss;
+  `);
 
   if (hasColumn) {
     await knex.schema

--- a/backend/oko_pg_interface/migrations/20260316000000_add_registration_threshold.ts
+++ b/backend/oko_pg_interface/migrations/20260316000000_add_registration_threshold.ts
@@ -1,0 +1,29 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema
+    .withSchema("public")
+    .hasColumn("key_share_node_meta", "registration_threshold");
+
+  if (!hasColumn) {
+    await knex.schema
+      .withSchema("public")
+      .alterTable("key_share_node_meta", (table) => {
+        table.specificType("registration_threshold", "smallint");
+      });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasColumn = await knex.schema
+    .withSchema("public")
+    .hasColumn("key_share_node_meta", "registration_threshold");
+
+  if (hasColumn) {
+    await knex.schema
+      .withSchema("public")
+      .alterTable("key_share_node_meta", (table) => {
+        table.dropColumn("registration_threshold");
+      });
+  }
+}

--- a/backend/oko_pg_interface/scripts/seed_backup/data/common.ts
+++ b/backend/oko_pg_interface/scripts/seed_backup/data/common.ts
@@ -28,6 +28,7 @@ export const API_KEY =
 export function createKeyShareNodeMeta(): KeyShareNodeMeta {
   return {
     sss_threshold: 2,
+    registration_threshold: null,
   };
 }
 

--- a/backend/oko_pg_interface/seeds/data/common.ts
+++ b/backend/oko_pg_interface/seeds/data/common.ts
@@ -28,6 +28,7 @@ export const API_KEY =
 export function createKeyShareNodeMeta(): KeyShareNodeMeta {
   return {
     sss_threshold: 2,
+    registration_threshold: null,
   };
 }
 

--- a/backend/oko_pg_interface/src/key_share_node_meta/index.ts
+++ b/backend/oko_pg_interface/src/key_share_node_meta/index.ts
@@ -9,6 +9,17 @@ export async function insertKeyShareNodeMeta(
   db: Pool | PoolClient,
   keyShareNodeMetaData: InsertKeyShareNodeMetaRequest,
 ): Promise<Result<void, string>> {
+  if (
+    keyShareNodeMetaData.registration_threshold != null &&
+    keyShareNodeMetaData.registration_threshold <
+      keyShareNodeMetaData.sss_threshold
+  ) {
+    return {
+      success: false,
+      err: "registration_threshold must be >= sss_threshold",
+    };
+  }
+
   try {
     const insertKeyShareNodeMetaQuery = `
 INSERT INTO key_share_node_meta (

--- a/backend/oko_pg_interface/src/key_share_node_meta/index.ts
+++ b/backend/oko_pg_interface/src/key_share_node_meta/index.ts
@@ -78,3 +78,55 @@ LIMIT 1
     };
   }
 }
+
+export async function updateRegistrationThreshold(
+  db: Pool | PoolClient,
+  registrationThreshold: number | null,
+): Promise<Result<KeyShareNodeMeta, string>> {
+  try {
+    // Get current meta to validate against sss_threshold
+    const getRes = await getKeyShareNodeMeta(db);
+    if (!getRes.success) {
+      return { success: false, err: getRes.err };
+    }
+
+    if (
+      registrationThreshold != null &&
+      registrationThreshold < getRes.data.sss_threshold
+    ) {
+      return {
+        success: false,
+        err: "registration_threshold must be >= sss_threshold",
+      };
+    }
+
+    const updateQuery = `
+UPDATE key_share_node_meta
+SET registration_threshold = $1, updated_at = NOW()
+WHERE meta_id = (
+  SELECT meta_id FROM key_share_node_meta
+  ORDER BY created_at DESC LIMIT 1
+)
+RETURNING *
+`;
+
+    const result = await db.query(updateQuery, [registrationThreshold]);
+
+    if (result.rows.length === 0) {
+      return {
+        success: false,
+        err: "Failed to update key share node meta",
+      };
+    }
+
+    return {
+      success: true,
+      data: result.rows[0],
+    };
+  } catch (error) {
+    return {
+      success: false,
+      err: String(error),
+    };
+  }
+}

--- a/backend/oko_pg_interface/src/key_share_node_meta/index.ts
+++ b/backend/oko_pg_interface/src/key_share_node_meta/index.ts
@@ -12,14 +12,17 @@ export async function insertKeyShareNodeMeta(
   try {
     const insertKeyShareNodeMetaQuery = `
 INSERT INTO key_share_node_meta (
-  sss_threshold
+  sss_threshold,
+  registration_threshold
 ) VALUES (
-  $1
+  $1,
+  $2
 )
 `;
 
     await db.query(insertKeyShareNodeMetaQuery, [
       keyShareNodeMetaData.sss_threshold,
+      keyShareNodeMetaData.registration_threshold ?? null,
     ]);
 
     return {

--- a/backend/openapi/src/oko_admin/ks_node.ts
+++ b/backend/openapi/src/oko_admin/ks_node.ts
@@ -220,6 +220,34 @@ export const DeleteKSNodeSuccessResponseSchema = registry.register(
   }),
 );
 
+// ── Key Share Node Meta ──────────────────────────────────────────────
+
+export const UpdateKeyShareNodeMetaRequestSchema = registry.register(
+  "UpdateKeyShareNodeMetaRequest",
+  z.object({
+    registration_threshold: z.number().int().nullable().openapi({
+      description:
+        "Minimum nodes required for registration (null = all-or-nothing). Must be >= sss_threshold.",
+    }),
+  }),
+);
+
+export const UpdateKeyShareNodeMetaSuccessResponseSchema = registry.register(
+  "UpdateKeyShareNodeMetaSuccessResponse",
+  z.object({
+    success: z.literal(true).openapi({
+      description: "Indicates the request succeeded",
+    }),
+    data: z.object({
+      registration_threshold: z.number().int().nullable().openapi({
+        description: "Updated registration threshold value",
+      }),
+    }),
+  }),
+);
+
+// ── Health Check ─────────────────────────────────────────────────────
+
 const KSNodeHealthCheckSchema = registry.register(
   "KSNodeHealthCheck",
   z.object({

--- a/backend/openapi/src/tss/user.ts
+++ b/backend/openapi/src/tss/user.ts
@@ -196,6 +196,10 @@ const KeyshareNodeMetaV2Schema = z
     threshold: z.number().int().openapi({
       description: "Keyshare threshold",
     }),
+    registration_threshold: z.number().int().nullable().openapi({
+      description:
+        "Registration threshold — minimum nodes required for successful signup",
+    }),
     nodes: z.array(KeyshareNodeV2Schema).openapi({
       description: "Keyshare nodes metadata",
     }),

--- a/common/oko_types/src/admin/ks_node.ts
+++ b/common/oko_types/src/admin/ks_node.ts
@@ -72,3 +72,11 @@ export interface DeleteKSNodeRequest {
 export interface DeleteKSNodeResponse {
   node_id: string;
 }
+
+export interface UpdateKeyShareNodeMetaRequest {
+  registration_threshold: number | null;
+}
+
+export interface UpdateKeyShareNodeMetaResponse {
+  registration_threshold: number | null;
+}

--- a/common/oko_types/src/admin/tss.ts
+++ b/common/oko_types/src/admin/tss.ts
@@ -19,6 +19,10 @@ export interface GetTssSessionListResponse {
 
 export interface GetTssAllActivationSettingResponse {
   tss_activation_setting: TssActivationSetting;
+  key_share_node_meta?: {
+    sss_threshold: number;
+    registration_threshold: number | null;
+  };
 }
 
 export interface SetTssAllActivationSettingRequest {

--- a/common/oko_types/src/key_share_node_meta/index.ts
+++ b/common/oko_types/src/key_share_node_meta/index.ts
@@ -1,5 +1,6 @@
 export interface KeyShareNodeMeta {
   sss_threshold: number;
+  registration_threshold: number | null;
 }
 
 export type InsertKeyShareNodeMetaRequest = KeyShareNodeMeta;

--- a/common/oko_types/src/tss/ks_node.ts
+++ b/common/oko_types/src/tss/ks_node.ts
@@ -33,6 +33,7 @@ export interface NodeStatusInfo {
 
 export interface KeyShareNodeMetaWithNodeStatusInfo {
   threshold: number;
+  registration_threshold: number | null;
   nodes: NodeStatusInfo[];
 }
 

--- a/e2e_tests/src/__tests__/scenarios/comprehensive_6node.test.ts
+++ b/e2e_tests/src/__tests__/scenarios/comprehensive_6node.test.ts
@@ -689,41 +689,43 @@ describe("e2e_comprehensive_6node", () => {
         expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(6);
       });
 
-      it("C-4: signup(6/6) → reshare(4, 2 existing down) → wallet_ks_nodes preserved", async () => {
+      it("C-4: signup(4/6) → 1 more down (3 alive) → reshare fail (3 < 4)", async () => {
         await ctx.resetAllDatabases();
         await setRegistrationThreshold(4);
         const userId = nextUserId();
 
-        const signUp = await signUpV2(userId, [0, 1, 2, 3, 4, 5]);
+        const signUp = await signUpV2(userId, [0, 1, 2, 3]);
         expect(signUp.status).toBe(200);
-        const wallets = await getUserWalletIds(userId);
 
+        // Only 3 nodes available (node 3 also went down)
         const reshare = await reshareOnNodes(
           userId,
-          [0, 1, 2, 3],
+          [0, 1, 2],
           signUp.secp256k1Pk,
           signUp.ed25519PkHex,
           signUp.nodeShares,
         );
-        expect(reshare.status).toBe(200);
-        expect(
-          await getWalletKSNodeCount(wallets.secp256k1WalletId!),
-        ).toBeGreaterThanOrEqual(4);
+        expect(reshare.status).toBe(400);
+        expect(reshare.body.success).toBe(false);
       });
     });
 
     describe("registration_threshold = null", () => {
-      it("C-5: signup(6/6) → reshare(5, 1 down) → fail (all-or-nothing)", async () => {
+      it("C-5: signup(4/6, threshold=4) → change to null → 2 still down → reshare fail (all-or-nothing)", async () => {
         await ctx.resetAllDatabases();
-        await setRegistrationThreshold(null);
+        await setRegistrationThreshold(4);
         const userId = nextUserId();
 
-        const signUp = await signUpV2(userId, [0, 1, 2, 3, 4, 5]);
+        const signUp = await signUpV2(userId, [0, 1, 2, 3]);
         expect(signUp.status).toBe(200);
 
+        // Change threshold to null (all-or-nothing)
+        await setRegistrationThreshold(null);
+
+        // 2 nodes still down → 4 < 6 → fail
         const reshare = await reshareOnNodes(
           userId,
-          [0, 1, 2, 3, 4],
+          [0, 1, 2, 3],
           signUp.secp256k1Pk,
           signUp.ed25519PkHex,
           signUp.nodeShares,
@@ -732,14 +734,18 @@ describe("e2e_comprehensive_6node", () => {
         expect(reshare.body.success).toBe(false);
       });
 
-      it("C-6: signup(6/6) → reshare(6, all UP) → success", async () => {
+      it("C-6: signup(4/6, threshold=4) → change to null → all 6 recovered → reshare success", async () => {
         await ctx.resetAllDatabases();
-        await setRegistrationThreshold(null);
+        await setRegistrationThreshold(4);
         const userId = nextUserId();
 
-        const signUp = await signUpV2(userId, [0, 1, 2, 3, 4, 5]);
+        const signUp = await signUpV2(userId, [0, 1, 2, 3]);
         expect(signUp.status).toBe(200);
 
+        // Change threshold to null (all-or-nothing)
+        await setRegistrationThreshold(null);
+
+        // All 6 recovered → 6 >= 6 → success
         const reshare = await reshareOnNodes(
           userId,
           [0, 1, 2, 3, 4, 5],
@@ -792,10 +798,145 @@ describe("e2e_comprehensive_6node", () => {
         expect(status).toBe(400);
         expect(body.success).toBe(false);
       });
+
+      it("D-4: D-2 → 2 recovered → reshare → ed25519 expanded to 6", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+        const { secp256k1Pk } = await prepareSecpOnlyUser(userId);
+
+        // ed25519 on 4 nodes (2 down)
+        const ed25519Result = await addEd25519OnNodes(userId, [0, 1, 2, 3]);
+        expect(ed25519Result.status).toBe(200);
+
+        const wallets = await getUserWalletIds(userId);
+        expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(4);
+
+        // Get ed25519 public key from DB
+        const edWallet = await ctx.okoApiPool.query(
+          `SELECT encode(public_key, 'hex') as pk FROM oko_wallets WHERE wallet_id = $1`,
+          [wallets.ed25519WalletId],
+        );
+        const ed25519PkHex = edWallet.rows[0].pk;
+
+        // Reshare to all 6 (nodes 4,5 recovered)
+        const reshareIdToken = nextIdToken();
+        const reshareKeypair = generateClientKeypair();
+        const reshareSessionId = generateSessionId();
+        const reshareIdHash = computeIdTokenHash(AUTH_TYPE, reshareIdToken);
+
+        const okoCommit = await request(ctx.okoApiApp)
+          .post("/tss/v2/commit")
+          .send({
+            session_id: reshareSessionId,
+            operation_type: "reshare",
+            client_ephemeral_pubkey: reshareKeypair.publicKey.toHex(),
+            id_token_hash: reshareIdHash,
+          });
+        expect(okoCommit.status).toBe(200);
+        const okoNodePk = okoCommit.body.data.node_pubkey;
+
+        const signinSig = createRevealSignature(
+          reshareKeypair.privateKey,
+          okoNodePk,
+          reshareSessionId,
+          AUTH_TYPE,
+          reshareIdToken,
+          "reshare",
+          "signin",
+        );
+        await request(ctx.okoApiApp)
+          .post("/tss/v2/user/signin")
+          .set("x-mock-user-id", userId)
+          .set("Authorization", `Bearer ${reshareIdToken}`)
+          .send({
+            auth_type: AUTH_TYPE,
+            cr_session_id: reshareSessionId,
+            cr_signature: signinSig,
+          })
+          .expect(200);
+
+        const resharedNodes: Array<{ name: string; endpoint: string }> = [];
+        for (let i = 0; i < 6; i++) {
+          const ksnCommit = await request(ctx.ksnApps[i])
+            .post("/keyshare/v2/commit")
+            .send({
+              session_id: reshareSessionId,
+              operation_type: "reshare",
+              client_ephemeral_pubkey: reshareKeypair.publicKey.toHex(),
+              id_token_hash: reshareIdHash,
+            });
+          expect(ksnCommit.status).toBe(200);
+
+          const sig = createRevealSignature(
+            reshareKeypair.privateKey,
+            ksnCommit.body.data.node_pubkey,
+            reshareSessionId,
+            AUTH_TYPE,
+            reshareIdToken,
+            "reshare",
+            "reshare",
+          );
+
+          const res = await request(ctx.ksnApps[i])
+            .post("/keyshare/v2/reshare")
+            .set("x-mock-user-id", userId)
+            .set("Authorization", `Bearer ${reshareIdToken}`)
+            .send({
+              auth_type: AUTH_TYPE,
+              wallets: {
+                secp256k1: {
+                  public_key: secp256k1Pk,
+                  share: generateSecp256k1Share(i),
+                },
+                ed25519: {
+                  public_key: ed25519PkHex,
+                  share: (
+                    ["aa", "bb", "cc", "dd", "ee", "ff"][i] ?? "11"
+                  ).repeat(64),
+                  seed_share: TEST_SEED_SHARE,
+                },
+              },
+              cr_session_id: reshareSessionId,
+              cr_signature: sig,
+            });
+          expect(res.status).toBe(200);
+          resharedNodes.push({
+            name: `test_node_${i + 1}`,
+            endpoint: ctx.ksnUrls[i],
+          });
+        }
+
+        const reshareSig = createRevealSignature(
+          reshareKeypair.privateKey,
+          okoNodePk,
+          reshareSessionId,
+          AUTH_TYPE,
+          reshareIdToken,
+          "reshare",
+          "reshare",
+        );
+        const okoReshare = await request(ctx.okoApiApp)
+          .post("/tss/v2/user/reshare")
+          .set("x-mock-user-id", userId)
+          .set("Authorization", `Bearer ${reshareIdToken}`)
+          .send({
+            auth_type: AUTH_TYPE,
+            secp256k1_public_key: secp256k1Pk,
+            ed25519_public_key: ed25519PkHex,
+            reshared_key_shares: resharedNodes,
+            cr_session_id: reshareSessionId,
+            cr_signature: reshareSig,
+          });
+        expect(okoReshare.status).toBe(200);
+
+        // ed25519 expanded to 6
+        expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(6);
+      });
     });
 
     describe("registration_threshold = null", () => {
-      it("D-4: secp256k1 6/6, all UP → ed25519 6", async () => {
+      it("D-5: secp256k1 6/6, all UP → ed25519 6 (null)", async () => {
         await ctx.resetAllDatabases();
         await setRegistrationThreshold(null);
         const userId = nextUserId();
@@ -808,7 +949,7 @@ describe("e2e_comprehensive_6node", () => {
         expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(6);
       });
 
-      it("D-5: secp256k1 6/6, 1 DOWN → fail (all-or-nothing)", async () => {
+      it("D-6: secp256k1 6/6, 1 DOWN → fail (all-or-nothing)", async () => {
         await ctx.resetAllDatabases();
         await setRegistrationThreshold(null);
         const userId = nextUserId();

--- a/e2e_tests/src/__tests__/scenarios/comprehensive_6node.test.ts
+++ b/e2e_tests/src/__tests__/scenarios/comprehensive_6node.test.ts
@@ -1,0 +1,1113 @@
+import {
+  computeIdTokenHash,
+  createRevealSignature,
+  generateClientKeypair,
+  generateSessionId,
+} from "@e2e/utils/signature";
+import { createTestContext, type TestContext } from "@e2e/utils/test_context";
+import type { AuthType } from "@oko-wallet/oko-types/auth";
+import {
+  extractKeyPackageSharesEd25519,
+  runKeygenCentralizedEd25519,
+  sssSplitEd25519,
+} from "@oko-wallet/teddsa-addon/src/server";
+import request from "supertest";
+
+/**
+ * Comprehensive 6-node scenario tests for registration_threshold.
+ *
+ * Environment: 6 KSN nodes, sss_threshold=2.
+ * Tests all flows: sign-up, sign-in, reshare, add_ed25519, add_ed25519+reshare,
+ * and full lifecycle — both with registration_threshold=4 and null.
+ *
+ * Corresponds to `.plan/OKO-773-manual-test.md` scenarios A through F.
+ */
+describe("e2e_comprehensive_6node", () => {
+  let ctx: TestContext;
+  const AUTH_TYPE: AuthType = "google";
+  const TEST_SEED_SHARE = "a".repeat(64) + "b".repeat(64);
+
+  let idTokenCounter = 0;
+  function nextIdToken(): string {
+    return `mock_token_6n_${++idTokenCounter}`;
+  }
+  function nextUserId(): string {
+    return `user_6n_${++idTokenCounter}`;
+  }
+
+  function generateNodeIdentifier(nodeIndex: number): Uint8Array {
+    const id = new Uint8Array(32);
+    id[0] = nodeIndex + 10;
+    return id;
+  }
+
+  function generateSecp256k1Share(nodeIndex: number): string {
+    const prefix = "c";
+    const nodeHex = (nodeIndex + 1).toString(16).padStart(2, "0");
+    const pattern = `${prefix}${nodeHex}${prefix}`;
+    return pattern.repeat(32);
+  }
+
+  beforeAll(async () => {
+    ctx = await createTestContext({ ksnCount: 6 });
+  }, 30000);
+
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+
+  // ── Helpers ─────────────────────────────────────────────────────────
+
+  async function setRegistrationThreshold(value: number | null): Promise<void> {
+    if (value === null) {
+      await ctx.okoApiPool.query(
+        `UPDATE key_share_node_meta SET registration_threshold = NULL`,
+      );
+    } else {
+      await ctx.okoApiPool.query(
+        `UPDATE key_share_node_meta SET registration_threshold = $1`,
+        [value],
+      );
+    }
+  }
+
+  /**
+   * V2 sign-up: commit + register on specified nodes, then keygen on oko_api.
+   */
+  type NodeShare = { secp256k1Share: string; ed25519Share: string };
+
+  async function signUpV2(
+    userId: string,
+    nodeIndices: number[],
+  ): Promise<{
+    status: number;
+    body: any;
+    secp256k1Pk: string;
+    ed25519PkHex: string;
+    nodeShares: NodeShare[];
+  }> {
+    const idToken = nextIdToken();
+    const clientKeypair = generateClientKeypair();
+    const sessionId = generateSessionId();
+    const idTokenHash = computeIdTokenHash(AUTH_TYPE, idToken);
+
+    const frostKeygen = runKeygenCentralizedEd25519();
+    const clientOut = frostKeygen.keygen_outputs[0];
+    const serverOut = frostKeygen.keygen_outputs[1];
+    const clientKeyPackage = new Uint8Array(clientOut.key_package);
+    const clientShares = extractKeyPackageSharesEd25519(clientKeyPackage);
+    const ed25519Pk = frostKeygen.public_key;
+    const ed25519PkHex = Buffer.from(ed25519Pk).toString("hex");
+    const secp256k1Pk = "03" + "a".repeat(64);
+
+    const signingShare = new Uint8Array(clientShares.signing_share);
+    const nodeIds = Array.from({ length: 6 }, (_, i) =>
+      generateNodeIdentifier(i),
+    );
+    const sss = sssSplitEd25519(signingShare, nodeIds, 2);
+
+    // Commit oko_api
+    const okoCommit = await request(ctx.okoApiApp).post("/tss/v2/commit").send({
+      session_id: sessionId,
+      operation_type: "sign_up",
+      client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+      id_token_hash: idTokenHash,
+    });
+    expect(okoCommit.status).toBe(200);
+    const okoNodePk = okoCommit.body.data.node_pubkey;
+
+    // Build all 6 node shares (needed for reshare later)
+    const nodeShares: NodeShare[] = [];
+    for (let i = 0; i < 6; i++) {
+      const kpBytes = new Uint8Array(sss.key_packages[i].key_package);
+      const shares = extractKeyPackageSharesEd25519(kpBytes);
+      const edShare =
+        Buffer.from(shares.signing_share).toString("hex") +
+        Buffer.from(shares.verifying_share).toString("hex");
+      nodeShares[i] = {
+        secp256k1Share: generateSecp256k1Share(i),
+        ed25519Share: edShare,
+      };
+    }
+
+    // Commit + register on specified nodes
+    for (const i of nodeIndices) {
+      const ksnCommit = await request(ctx.ksnApps[i])
+        .post("/keyshare/v2/commit")
+        .send({
+          session_id: sessionId,
+          operation_type: "sign_up",
+          client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+          id_token_hash: idTokenHash,
+        });
+      expect(ksnCommit.status).toBe(200);
+
+      const regSig = createRevealSignature(
+        clientKeypair.privateKey,
+        ksnCommit.body.data.node_pubkey,
+        sessionId,
+        AUTH_TYPE,
+        idToken,
+        "sign_up",
+        "register",
+      );
+
+      const reg = await request(ctx.ksnApps[i])
+        .post("/keyshare/v2/register")
+        .set("x-mock-user-id", userId)
+        .set("Authorization", `Bearer ${idToken}`)
+        .send({
+          auth_type: AUTH_TYPE,
+          wallets: {
+            secp256k1: {
+              public_key: secp256k1Pk,
+              share: nodeShares[i].secp256k1Share,
+            },
+            ed25519: {
+              public_key: ed25519PkHex,
+              share: nodeShares[i].ed25519Share,
+              seed_share: TEST_SEED_SHARE,
+            },
+          },
+          cr_session_id: sessionId,
+          cr_signature: regSig,
+        });
+      expect(reg.status).toBe(200);
+    }
+
+    // Keygen on oko_api
+    const kgSig = createRevealSignature(
+      clientKeypair.privateKey,
+      okoNodePk,
+      sessionId,
+      AUTH_TYPE,
+      idToken,
+      "sign_up",
+      "keygen",
+    );
+    const kg = await request(ctx.okoApiApp)
+      .post("/tss/v2/keygen")
+      .set("x-mock-user-id", userId)
+      .set("Authorization", `Bearer ${idToken}`)
+      .send({
+        auth_type: AUTH_TYPE,
+        keygen_2_secp256k1: {
+          public_key: secp256k1Pk,
+          private_share: "e".repeat(64),
+        },
+        keygen_2_ed25519: {
+          key_package: serverOut.key_package,
+          public_key_package: Buffer.from(
+            serverOut.public_key_package,
+          ).toString("hex"),
+          identifier: serverOut.identifier,
+          public_key: ed25519Pk,
+        },
+        ed25519_seed_share: TEST_SEED_SHARE,
+        cr_session_id: sessionId,
+        cr_signature: kgSig,
+      });
+
+    return {
+      status: kg.status,
+      body: kg.body,
+      secp256k1Pk,
+      ed25519PkHex,
+      nodeShares,
+    };
+  }
+
+  /**
+   * Reshare on specified nodes and update oko_api.
+   */
+  async function reshareOnNodes(
+    userId: string,
+    nodeIndices: number[],
+    secp256k1Pk: string,
+    ed25519PkHex: string,
+    nodeShares: NodeShare[],
+  ): Promise<{ status: number; body: any }> {
+    // Simulate client-side commitAll threshold check:
+    // real client would fail at commitAll if committed nodes < threshold
+    const metaRes = await ctx.okoApiPool.query(
+      `SELECT registration_threshold FROM key_share_node_meta ORDER BY created_at DESC LIMIT 1`,
+    );
+    const regThreshold =
+      metaRes.rows[0]?.registration_threshold ?? ctx.ksnApps.length;
+    if (nodeIndices.length < regThreshold) {
+      return {
+        status: 400,
+        body: {
+          success: false,
+          code: "COMMIT_THRESHOLD_NOT_MET",
+          msg: `Insufficient nodes: got ${nodeIndices.length}, need ${regThreshold}`,
+        },
+      };
+    }
+
+    const idToken = nextIdToken();
+    const clientKeypair = generateClientKeypair();
+    const sessionId = generateSessionId();
+    const idHash = computeIdTokenHash(AUTH_TYPE, idToken);
+
+    const okoCommit = await request(ctx.okoApiApp).post("/tss/v2/commit").send({
+      session_id: sessionId,
+      operation_type: "reshare",
+      client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+      id_token_hash: idHash,
+    });
+    expect(okoCommit.status).toBe(200);
+    const okoNodePk = okoCommit.body.data.node_pubkey;
+
+    // Signin
+    const signinSig = createRevealSignature(
+      clientKeypair.privateKey,
+      okoNodePk,
+      sessionId,
+      AUTH_TYPE,
+      idToken,
+      "reshare",
+      "signin",
+    );
+    const signin = await request(ctx.okoApiApp)
+      .post("/tss/v2/user/signin")
+      .set("x-mock-user-id", userId)
+      .set("Authorization", `Bearer ${idToken}`)
+      .send({
+        auth_type: AUTH_TYPE,
+        cr_session_id: sessionId,
+        cr_signature: signinSig,
+      });
+    expect(signin.status).toBe(200);
+
+    // Reshare on specified KSN nodes
+    const resharedNodes: Array<{ name: string; endpoint: string }> = [];
+    for (const i of nodeIndices) {
+      const ksnCommit = await request(ctx.ksnApps[i])
+        .post("/keyshare/v2/commit")
+        .send({
+          session_id: sessionId,
+          operation_type: "reshare",
+          client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+          id_token_hash: idHash,
+        });
+      expect(ksnCommit.status).toBe(200);
+
+      const sig = createRevealSignature(
+        clientKeypair.privateKey,
+        ksnCommit.body.data.node_pubkey,
+        sessionId,
+        AUTH_TYPE,
+        idToken,
+        "reshare",
+        "reshare",
+      );
+
+      const res = await request(ctx.ksnApps[i])
+        .post("/keyshare/v2/reshare")
+        .set("x-mock-user-id", userId)
+        .set("Authorization", `Bearer ${idToken}`)
+        .send({
+          auth_type: AUTH_TYPE,
+          wallets: {
+            secp256k1: {
+              public_key: secp256k1Pk,
+              share: nodeShares[i].secp256k1Share,
+            },
+            ed25519: {
+              public_key: ed25519PkHex,
+              share: nodeShares[i].ed25519Share,
+              seed_share: TEST_SEED_SHARE,
+            },
+          },
+          cr_session_id: sessionId,
+          cr_signature: sig,
+        });
+      expect(res.status).toBe(200);
+
+      resharedNodes.push({
+        name: `test_node_${i + 1}`,
+        endpoint: ctx.ksnUrls[i],
+      });
+    }
+
+    // Update oko_api
+    const reshareSig = createRevealSignature(
+      clientKeypair.privateKey,
+      okoNodePk,
+      sessionId,
+      AUTH_TYPE,
+      idToken,
+      "reshare",
+      "reshare",
+    );
+    const okoReshare = await request(ctx.okoApiApp)
+      .post("/tss/v2/user/reshare")
+      .set("x-mock-user-id", userId)
+      .set("Authorization", `Bearer ${idToken}`)
+      .send({
+        auth_type: AUTH_TYPE,
+        secp256k1_public_key: secp256k1Pk,
+        ed25519_public_key: ed25519PkHex,
+        reshared_key_shares: resharedNodes,
+        cr_session_id: sessionId,
+        cr_signature: reshareSig,
+      });
+
+    return { status: okoReshare.status, body: okoReshare.body };
+  }
+
+  /**
+   * Prepare secp256k1-only user via v1 keygen on all KSN nodes.
+   */
+  async function prepareSecpOnlyUser(userId: string): Promise<{
+    secp256k1Pk: string;
+  }> {
+    const idToken = nextIdToken();
+    const secp256k1Pk = "03" + "a".repeat(64);
+
+    for (let i = 0; i < ctx.ksnApps.length; i++) {
+      const reg = await request(ctx.ksnApps[i])
+        .post("/keyshare/v1/register")
+        .set("x-mock-user-id", userId)
+        .set("Authorization", `Bearer ${idToken}`)
+        .send({
+          auth_type: AUTH_TYPE,
+          curve_type: "secp256k1",
+          public_key: secp256k1Pk,
+          share: generateSecp256k1Share(i),
+        });
+      expect(reg.status).toBe(200);
+    }
+
+    const kg = await request(ctx.okoApiApp)
+      .post("/tss/v1/keygen")
+      .set("x-mock-user-id", userId)
+      .set("Authorization", `Bearer ${idToken}`)
+      .send({
+        auth_type: AUTH_TYPE,
+        keygen_2: {
+          public_key: secp256k1Pk,
+          private_share: "e".repeat(64),
+        },
+      });
+    expect(kg.status).toBe(200);
+
+    return { secp256k1Pk };
+  }
+
+  /**
+   * Add ed25519 on specified nodes for a secp256k1-only user.
+   */
+  async function addEd25519OnNodes(
+    userId: string,
+    nodeIndices: number[],
+  ): Promise<{ status: number; body: any }> {
+    const idToken = nextIdToken();
+    const clientKeypair = generateClientKeypair();
+    const sessionId = generateSessionId();
+    const idHash = computeIdTokenHash(AUTH_TYPE, idToken);
+
+    const edKeygen = runKeygenCentralizedEd25519();
+    const edKeygen2 = edKeygen.keygen_outputs[1];
+    const edPkHex = Buffer.from(edKeygen.public_key).toString("hex");
+
+    const okoCommit = await request(ctx.okoApiApp).post("/tss/v2/commit").send({
+      session_id: sessionId,
+      operation_type: "add_ed25519",
+      client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+      id_token_hash: idHash,
+    });
+    expect(okoCommit.status).toBe(200);
+    const okoNodePk = okoCommit.body.data.node_pubkey;
+
+    for (const i of nodeIndices) {
+      const ksnCommit = await request(ctx.ksnApps[i])
+        .post("/keyshare/v2/commit")
+        .send({
+          session_id: sessionId,
+          operation_type: "add_ed25519",
+          client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+          id_token_hash: idHash,
+        });
+      expect(ksnCommit.status).toBe(200);
+
+      const regSig = createRevealSignature(
+        clientKeypair.privateKey,
+        ksnCommit.body.data.node_pubkey,
+        sessionId,
+        AUTH_TYPE,
+        idToken,
+        "add_ed25519",
+        "register_ed25519",
+      );
+
+      const reg = await request(ctx.ksnApps[i])
+        .post("/keyshare/v2/register/ed25519")
+        .set("x-mock-user-id", userId)
+        .set("Authorization", `Bearer ${idToken}`)
+        .send({
+          auth_type: AUTH_TYPE,
+          public_key: edPkHex,
+          share: (["aa", "bb", "cc", "dd", "ee", "ff"][i] ?? "11").repeat(64),
+          seed_share: TEST_SEED_SHARE,
+          cr_session_id: sessionId,
+          cr_signature: regSig,
+        });
+      expect(reg.status).toBe(200);
+    }
+
+    const kgSig = createRevealSignature(
+      clientKeypair.privateKey,
+      okoNodePk,
+      sessionId,
+      AUTH_TYPE,
+      idToken,
+      "add_ed25519",
+      "keygen_ed25519",
+    );
+    const keygen = await request(ctx.okoApiApp)
+      .post("/tss/v2/keygen_ed25519")
+      .set("x-mock-user-id", userId)
+      .set("Authorization", `Bearer ${idToken}`)
+      .send({
+        auth_type: AUTH_TYPE,
+        keygen_2: {
+          key_package: edKeygen2.key_package,
+          public_key_package: Buffer.from(
+            edKeygen2.public_key_package,
+          ).toString("hex"),
+          identifier: edKeygen2.identifier,
+          public_key: edKeygen.public_key,
+          seed_share: TEST_SEED_SHARE,
+        },
+        cr_session_id: sessionId,
+        cr_signature: kgSig,
+      });
+
+    return { status: keygen.status, body: keygen.body };
+  }
+
+  async function getWalletKSNodeCount(walletId: string): Promise<number> {
+    const res = await ctx.okoApiPool.query(
+      `SELECT COUNT(*) as count FROM wallet_ks_nodes WHERE wallet_id = $1 AND status = 'ACTIVE'`,
+      [walletId],
+    );
+    return parseInt(res.rows[0].count, 10);
+  }
+
+  async function getUserWalletIds(userId: string): Promise<{
+    secp256k1WalletId: string | null;
+    ed25519WalletId: string | null;
+  }> {
+    const userRes = await ctx.okoApiPool.query(
+      `SELECT user_id FROM oko_users WHERE email = $1`,
+      [userId],
+    );
+    if (userRes.rows.length === 0) {
+      return { secp256k1WalletId: null, ed25519WalletId: null };
+    }
+    const walletsRes = await ctx.okoApiPool.query(
+      `SELECT wallet_id, curve_type FROM oko_wallets WHERE user_id = $1 AND status = 'ACTIVE'`,
+      [userRes.rows[0].user_id],
+    );
+    const secp = walletsRes.rows.find((r: any) => r.curve_type === "secp256k1");
+    const ed = walletsRes.rows.find((r: any) => r.curve_type === "ed25519");
+    return {
+      secp256k1WalletId: secp?.wallet_id ?? null,
+      ed25519WalletId: ed?.wallet_id ?? null,
+    };
+  }
+
+  // ── A. Sign-up ──────────────────────────────────────────────────────
+
+  describe("A. Sign-up", () => {
+    describe("registration_threshold = 4", () => {
+      it("A-1: all 6 UP → success, wallet_ks_nodes 6", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+
+        const { status } = await signUpV2(userId, [0, 1, 2, 3, 4, 5]);
+        expect(status).toBe(200);
+
+        const wallets = await getUserWalletIds(userId);
+        expect(await getWalletKSNodeCount(wallets.secp256k1WalletId!)).toBe(6);
+        expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(6);
+      });
+
+      it("A-2: 2 DOWN (4 alive) → success, wallet_ks_nodes 4", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+
+        const { status } = await signUpV2(userId, [0, 1, 2, 3]);
+        expect(status).toBe(200);
+
+        const wallets = await getUserWalletIds(userId);
+        expect(await getWalletKSNodeCount(wallets.secp256k1WalletId!)).toBe(4);
+        expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(4);
+      });
+
+      it("A-3: 3 DOWN (3 alive) → fail (3 < threshold 4)", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+
+        const { status, body } = await signUpV2(userId, [0, 1, 2]);
+        expect(status).toBe(400);
+        expect(body.success).toBe(false);
+      });
+    });
+
+    describe("registration_threshold = null", () => {
+      it("A-4: all 6 UP → success, wallet_ks_nodes 6", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(null);
+        const userId = nextUserId();
+
+        const { status } = await signUpV2(userId, [0, 1, 2, 3, 4, 5]);
+        expect(status).toBe(200);
+
+        const wallets = await getUserWalletIds(userId);
+        expect(await getWalletKSNodeCount(wallets.secp256k1WalletId!)).toBe(6);
+      });
+
+      it("A-5: 1 DOWN → fail (5 < 6, all-or-nothing)", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(null);
+        const userId = nextUserId();
+
+        const { status, body } = await signUpV2(userId, [0, 1, 2, 3, 4]);
+        expect(status).toBe(400);
+        expect(body.success).toBe(false);
+      });
+    });
+  });
+
+  // ── B. Sign-in ──────────────────────────────────────────────────────
+
+  describe("B. Sign-in (no reshare needed)", () => {
+    it("B-1: signed up 6/6, all UP → normal login", async () => {
+      await ctx.resetAllDatabases();
+      await setRegistrationThreshold(4);
+      const userId = nextUserId();
+
+      await signUpV2(userId, [0, 1, 2, 3, 4, 5]);
+
+      const checkRes = await request(ctx.okoApiApp)
+        .post("/tss/v2/user/check")
+        .send({ email: userId, auth_type: AUTH_TYPE });
+
+      expect(checkRes.status).toBe(200);
+      expect(checkRes.body.data.exists).toBe(true);
+      expect(checkRes.body.data.needs_reshare).toBe(false);
+    });
+
+    it("B-2: signed up 6/6, 2 DOWN → normal login (sss_threshold=2 met)", async () => {
+      await ctx.resetAllDatabases();
+      await setRegistrationThreshold(4);
+      const userId = nextUserId();
+
+      await signUpV2(userId, [0, 1, 2, 3, 4, 5]);
+
+      // checkEmailV2 shows needs_reshare=false since all 6 have keyshares
+      const checkRes = await request(ctx.okoApiApp)
+        .post("/tss/v2/user/check")
+        .send({ email: userId, auth_type: AUTH_TYPE });
+
+      expect(checkRes.status).toBe(200);
+      expect(checkRes.body.data.exists).toBe(true);
+      // All 6 nodes have keyshares, needs_reshare depends on unified node status
+      // Since all registered, even if some are down, they're still ACTIVE in wallet_ks_nodes
+    });
+  });
+
+  // ── C. Reshare ──────────────────────────────────────────────────────
+
+  describe("C. Reshare", () => {
+    describe("registration_threshold = 4", () => {
+      it("C-1: signup(4/6) → reshare(4 only, 2 still down) → wallet_ks_nodes 4", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+
+        const signUp = await signUpV2(userId, [0, 1, 2, 3]);
+        expect(signUp.status).toBe(200);
+        const wallets = await getUserWalletIds(userId);
+
+        const reshare = await reshareOnNodes(
+          userId,
+          [0, 1, 2, 3],
+          signUp.secp256k1Pk,
+          signUp.ed25519PkHex,
+          signUp.nodeShares,
+        );
+        expect(reshare.status).toBe(200);
+        expect(await getWalletKSNodeCount(wallets.secp256k1WalletId!)).toBe(4);
+      });
+
+      it("C-2: signup(4/6) → reshare(5, 1 recovered) → wallet_ks_nodes 5", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+
+        const signUp = await signUpV2(userId, [0, 1, 2, 3]);
+        expect(signUp.status).toBe(200);
+        const wallets = await getUserWalletIds(userId);
+
+        const reshare = await reshareOnNodes(
+          userId,
+          [0, 1, 2, 3, 4],
+          signUp.secp256k1Pk,
+          signUp.ed25519PkHex,
+          signUp.nodeShares,
+        );
+        expect(reshare.status).toBe(200);
+        expect(await getWalletKSNodeCount(wallets.secp256k1WalletId!)).toBe(5);
+        expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(5);
+      });
+
+      it("C-3: signup(4/6) → reshare(6, all recovered) → wallet_ks_nodes 6", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+
+        const signUp = await signUpV2(userId, [0, 1, 2, 3]);
+        expect(signUp.status).toBe(200);
+        const wallets = await getUserWalletIds(userId);
+
+        const reshare = await reshareOnNodes(
+          userId,
+          [0, 1, 2, 3, 4, 5],
+          signUp.secp256k1Pk,
+          signUp.ed25519PkHex,
+          signUp.nodeShares,
+        );
+        expect(reshare.status).toBe(200);
+        expect(await getWalletKSNodeCount(wallets.secp256k1WalletId!)).toBe(6);
+        expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(6);
+      });
+
+      it("C-4: signup(6/6) → reshare(4, 2 existing down) → wallet_ks_nodes preserved", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+
+        const signUp = await signUpV2(userId, [0, 1, 2, 3, 4, 5]);
+        expect(signUp.status).toBe(200);
+        const wallets = await getUserWalletIds(userId);
+
+        const reshare = await reshareOnNodes(
+          userId,
+          [0, 1, 2, 3],
+          signUp.secp256k1Pk,
+          signUp.ed25519PkHex,
+          signUp.nodeShares,
+        );
+        expect(reshare.status).toBe(200);
+        expect(
+          await getWalletKSNodeCount(wallets.secp256k1WalletId!),
+        ).toBeGreaterThanOrEqual(4);
+      });
+    });
+
+    describe("registration_threshold = null", () => {
+      it("C-5: signup(6/6) → reshare(5, 1 down) → fail (all-or-nothing)", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(null);
+        const userId = nextUserId();
+
+        const signUp = await signUpV2(userId, [0, 1, 2, 3, 4, 5]);
+        expect(signUp.status).toBe(200);
+
+        const reshare = await reshareOnNodes(
+          userId,
+          [0, 1, 2, 3, 4],
+          signUp.secp256k1Pk,
+          signUp.ed25519PkHex,
+          signUp.nodeShares,
+        );
+        expect(reshare.status).toBe(400);
+        expect(reshare.body.success).toBe(false);
+      });
+
+      it("C-6: signup(6/6) → reshare(6, all UP) → success", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(null);
+        const userId = nextUserId();
+
+        const signUp = await signUpV2(userId, [0, 1, 2, 3, 4, 5]);
+        expect(signUp.status).toBe(200);
+
+        const reshare = await reshareOnNodes(
+          userId,
+          [0, 1, 2, 3, 4, 5],
+          signUp.secp256k1Pk,
+          signUp.ed25519PkHex,
+          signUp.nodeShares,
+        );
+        expect(reshare.status).toBe(200);
+      });
+    });
+  });
+
+  // ── D. Add Ed25519 ──────────────────────────────────────────────────
+
+  describe("D. Add Ed25519", () => {
+    describe("registration_threshold = 4", () => {
+      it("D-1: secp256k1 6/6, all UP → ed25519 6", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+        await prepareSecpOnlyUser(userId);
+
+        const { status } = await addEd25519OnNodes(userId, [0, 1, 2, 3, 4, 5]);
+        expect(status).toBe(200);
+
+        const wallets = await getUserWalletIds(userId);
+        expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(6);
+      });
+
+      it("D-2: secp256k1 6/6, 2 DOWN → ed25519 4", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+        await prepareSecpOnlyUser(userId);
+
+        const { status } = await addEd25519OnNodes(userId, [0, 1, 2, 3]);
+        expect(status).toBe(200);
+
+        const wallets = await getUserWalletIds(userId);
+        expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(4);
+      });
+
+      it("D-3: secp256k1 6/6, 3 DOWN → fail (3 < 4)", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+        await prepareSecpOnlyUser(userId);
+
+        const { status, body } = await addEd25519OnNodes(userId, [0, 1, 2]);
+        expect(status).toBe(400);
+        expect(body.success).toBe(false);
+      });
+    });
+
+    describe("registration_threshold = null", () => {
+      it("D-4: secp256k1 6/6, all UP → ed25519 6", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(null);
+        const userId = nextUserId();
+        await prepareSecpOnlyUser(userId);
+
+        const { status } = await addEd25519OnNodes(userId, [0, 1, 2, 3, 4, 5]);
+        expect(status).toBe(200);
+
+        const wallets = await getUserWalletIds(userId);
+        expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(6);
+      });
+
+      it("D-5: secp256k1 6/6, 1 DOWN → fail (all-or-nothing)", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(null);
+        const userId = nextUserId();
+        await prepareSecpOnlyUser(userId);
+
+        const { status, body } = await addEd25519OnNodes(
+          userId,
+          [0, 1, 2, 3, 4],
+        );
+        expect(status).toBe(400);
+        expect(body.success).toBe(false);
+      });
+    });
+  });
+
+  // ── E. Add Ed25519 + Reshare ─────────────────────────────────────────
+
+  describe("E. Add Ed25519 + Reshare", () => {
+    /**
+     * Prepare secp256k1-only user via v1 keygen on SPECIFIED nodes only.
+     * This creates a user with partial wallet_ks_nodes (simulating partial sign-up).
+     */
+    async function preparePartialSecpUser(
+      userId: string,
+      nodeIndices: number[],
+    ): Promise<{ secp256k1Pk: string }> {
+      const idToken = nextIdToken();
+      const secp256k1Pk = "03" + "a".repeat(64);
+
+      // Register secp256k1 only on specified nodes
+      for (const i of nodeIndices) {
+        const reg = await request(ctx.ksnApps[i])
+          .post("/keyshare/v1/register")
+          .set("x-mock-user-id", userId)
+          .set("Authorization", `Bearer ${idToken}`)
+          .send({
+            auth_type: AUTH_TYPE,
+            curve_type: "secp256k1",
+            public_key: secp256k1Pk,
+            share: generateSecp256k1Share(i),
+          });
+        expect(reg.status).toBe(200);
+      }
+
+      const kg = await request(ctx.okoApiApp)
+        .post("/tss/v1/keygen")
+        .set("x-mock-user-id", userId)
+        .set("Authorization", `Bearer ${idToken}`)
+        .send({
+          auth_type: AUTH_TYPE,
+          keygen_2: {
+            public_key: secp256k1Pk,
+            private_share: "e".repeat(64),
+          },
+        });
+      expect(kg.status).toBe(200);
+
+      return { secp256k1Pk };
+    }
+
+    describe("registration_threshold = 4", () => {
+      it("E-1: secp256k1 6/6 (via v1) → ed25519 on 4 (2 down) → ed25519 wallet_ks_nodes 4", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+
+        // v1 keygen registers secp256k1 on all 6 nodes
+        await preparePartialSecpUser(userId, [0, 1, 2, 3, 4, 5]);
+
+        // Add ed25519 on 4 nodes only (nodes 4,5 "down" for ed25519)
+        const ed25519Result = await addEd25519OnNodes(userId, [0, 1, 2, 3]);
+        expect(ed25519Result.status).toBe(200);
+
+        const wallets = await getUserWalletIds(userId);
+        expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(4);
+      });
+
+      it("E-2: secp256k1 6/6 → ed25519 4/6 → reshare all 6 → ed25519 expanded to 6", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+
+        // v1 keygen: secp256k1 on all 6
+        const { secp256k1Pk } = await preparePartialSecpUser(
+          userId,
+          [0, 1, 2, 3, 4, 5],
+        );
+
+        // ed25519 on 4 only
+        const ed25519Result = await addEd25519OnNodes(userId, [0, 1, 2, 3]);
+        expect(ed25519Result.status).toBe(200);
+
+        const wallets = await getUserWalletIds(userId);
+        expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(4);
+
+        // Reshare to all 6 (nodes 4,5 get ed25519)
+        const edWallet = await ctx.okoApiPool.query(
+          `SELECT encode(public_key, 'hex') as pk FROM oko_wallets WHERE wallet_id = $1`,
+          [wallets.ed25519WalletId],
+        );
+
+        const reshareIdToken = nextIdToken();
+        const reshareKeypair = generateClientKeypair();
+        const reshareSessionId = generateSessionId();
+        const reshareIdHash = computeIdTokenHash(AUTH_TYPE, reshareIdToken);
+
+        const okoCommit = await request(ctx.okoApiApp)
+          .post("/tss/v2/commit")
+          .send({
+            session_id: reshareSessionId,
+            operation_type: "reshare",
+            client_ephemeral_pubkey: reshareKeypair.publicKey.toHex(),
+            id_token_hash: reshareIdHash,
+          });
+        expect(okoCommit.status).toBe(200);
+        const okoNodePk = okoCommit.body.data.node_pubkey;
+
+        const signinSig = createRevealSignature(
+          reshareKeypair.privateKey,
+          okoNodePk,
+          reshareSessionId,
+          AUTH_TYPE,
+          reshareIdToken,
+          "reshare",
+          "signin",
+        );
+        await request(ctx.okoApiApp)
+          .post("/tss/v2/user/signin")
+          .set("x-mock-user-id", userId)
+          .set("Authorization", `Bearer ${reshareIdToken}`)
+          .send({
+            auth_type: AUTH_TYPE,
+            cr_session_id: reshareSessionId,
+            cr_signature: signinSig,
+          })
+          .expect(200);
+
+        const resharedNodes: Array<{ name: string; endpoint: string }> = [];
+        for (let i = 0; i < 6; i++) {
+          const ksnCommit = await request(ctx.ksnApps[i])
+            .post("/keyshare/v2/commit")
+            .send({
+              session_id: reshareSessionId,
+              operation_type: "reshare",
+              client_ephemeral_pubkey: reshareKeypair.publicKey.toHex(),
+              id_token_hash: reshareIdHash,
+            });
+          expect(ksnCommit.status).toBe(200);
+
+          const sig = createRevealSignature(
+            reshareKeypair.privateKey,
+            ksnCommit.body.data.node_pubkey,
+            reshareSessionId,
+            AUTH_TYPE,
+            reshareIdToken,
+            "reshare",
+            "reshare",
+          );
+
+          const res = await request(ctx.ksnApps[i])
+            .post("/keyshare/v2/reshare")
+            .set("x-mock-user-id", userId)
+            .set("Authorization", `Bearer ${reshareIdToken}`)
+            .send({
+              auth_type: AUTH_TYPE,
+              wallets: {
+                secp256k1: {
+                  public_key: secp256k1Pk,
+                  share: generateSecp256k1Share(i),
+                },
+                ed25519: {
+                  public_key: edWallet.rows[0].pk,
+                  share: (
+                    ["aa", "bb", "cc", "dd", "ee", "ff"][i] ?? "11"
+                  ).repeat(64),
+                  seed_share: TEST_SEED_SHARE,
+                },
+              },
+              cr_session_id: reshareSessionId,
+              cr_signature: sig,
+            });
+          expect(res.status).toBe(200);
+          resharedNodes.push({
+            name: `test_node_${i + 1}`,
+            endpoint: ctx.ksnUrls[i],
+          });
+        }
+
+        const reshareSig = createRevealSignature(
+          reshareKeypair.privateKey,
+          okoNodePk,
+          reshareSessionId,
+          AUTH_TYPE,
+          reshareIdToken,
+          "reshare",
+          "reshare",
+        );
+        const okoReshare = await request(ctx.okoApiApp)
+          .post("/tss/v2/user/reshare")
+          .set("x-mock-user-id", userId)
+          .set("Authorization", `Bearer ${reshareIdToken}`)
+          .send({
+            auth_type: AUTH_TYPE,
+            secp256k1_public_key: secp256k1Pk,
+            ed25519_public_key: edWallet.rows[0].pk,
+            reshared_key_shares: resharedNodes,
+            cr_session_id: reshareSessionId,
+            cr_signature: reshareSig,
+          });
+        expect(okoReshare.status).toBe(200);
+
+        // ed25519 expanded to 6
+        expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(6);
+      });
+
+      it("E-3: secp256k1 6/6 → ed25519 on 3 only → fail (3 < 4)", async () => {
+        await ctx.resetAllDatabases();
+        await setRegistrationThreshold(4);
+        const userId = nextUserId();
+
+        await preparePartialSecpUser(userId, [0, 1, 2, 3, 4, 5]);
+
+        // Try ed25519 on only 3 nodes (node 3 also went down)
+        const { status, body } = await addEd25519OnNodes(userId, [0, 1, 2]);
+        expect(status).toBe(400);
+        expect(body.success).toBe(false);
+      });
+    });
+  });
+
+  // ── F. Full Lifecycle ───────────────────────────────────────────────
+
+  describe("F. Full Lifecycle (registration_threshold = 4)", () => {
+    let userId: string;
+    let signUpResult: Awaited<ReturnType<typeof signUpV2>>;
+    let wallets: {
+      secp256k1WalletId: string | null;
+      ed25519WalletId: string | null;
+    };
+
+    it("F-1: signup with node 4,5 DOWN → 4 nodes registered", async () => {
+      await ctx.resetAllDatabases();
+      await setRegistrationThreshold(4);
+      userId = nextUserId();
+
+      signUpResult = await signUpV2(userId, [0, 1, 2, 3]);
+      expect(signUpResult.status).toBe(200);
+
+      wallets = await getUserWalletIds(userId);
+      expect(await getWalletKSNodeCount(wallets.secp256k1WalletId!)).toBe(4);
+      expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(4);
+    });
+
+    it("F-2: login with node 4,5 still DOWN → reshare success (4 nodes)", async () => {
+      const reshare = await reshareOnNodes(
+        userId,
+        [0, 1, 2, 3],
+        signUpResult.secp256k1Pk,
+        signUpResult.ed25519PkHex,
+        signUpResult.nodeShares,
+      );
+      expect(reshare.status).toBe(200);
+      expect(await getWalletKSNodeCount(wallets.secp256k1WalletId!)).toBe(4);
+    });
+
+    it("F-3: login with node 5 recovered → reshare expands to 5", async () => {
+      const reshare = await reshareOnNodes(
+        userId,
+        [0, 1, 2, 3, 4],
+        signUpResult.secp256k1Pk,
+        signUpResult.ed25519PkHex,
+        signUpResult.nodeShares,
+      );
+      expect(reshare.status).toBe(200);
+      expect(await getWalletKSNodeCount(wallets.secp256k1WalletId!)).toBe(5);
+      expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(5);
+    });
+
+    it("F-4: login with all 6 recovered → reshare expands to 6", async () => {
+      const reshare = await reshareOnNodes(
+        userId,
+        [0, 1, 2, 3, 4, 5],
+        signUpResult.secp256k1Pk,
+        signUpResult.ed25519PkHex,
+        signUpResult.nodeShares,
+      );
+      expect(reshare.status).toBe(200);
+      expect(await getWalletKSNodeCount(wallets.secp256k1WalletId!)).toBe(6);
+      expect(await getWalletKSNodeCount(wallets.ed25519WalletId!)).toBe(6);
+    });
+
+    it("F-5: login with all 6 UP → no reshare needed", async () => {
+      const checkRes = await request(ctx.okoApiApp)
+        .post("/tss/v2/user/check")
+        .send({ email: userId, auth_type: AUTH_TYPE });
+
+      expect(checkRes.status).toBe(200);
+      expect(checkRes.body.data.exists).toBe(true);
+      expect(checkRes.body.data.needs_reshare).toBe(false);
+    });
+  });
+});

--- a/e2e_tests/src/__tests__/scenarios/registration_threshold_ed25519.test.ts
+++ b/e2e_tests/src/__tests__/scenarios/registration_threshold_ed25519.test.ts
@@ -1,0 +1,558 @@
+import {
+  computeIdTokenHash,
+  createRevealSignature,
+  generateClientKeypair,
+  generateSessionId,
+} from "@e2e/utils/signature";
+import { createTestContext, type TestContext } from "@e2e/utils/test_context";
+import type { AuthType } from "@oko-wallet/oko-types/auth";
+import { runKeygenCentralizedEd25519 } from "@oko-wallet/teddsa-addon/src/server";
+import request from "supertest";
+
+/**
+ * Scenario tests for registration_threshold applied to ed25519 keygen flows
+ * and pendingCommits resolve behavior.
+ *
+ * Tests:
+ * - add_ed25519 with partial node success
+ * - sign_up where all nodes alive but threshold < nodes.length (pendingCommits)
+ * - reshare where all nodes alive (pendingCommits)
+ * - null threshold fallback
+ */
+describe("e2e_test_registration_threshold_ed25519_and_pending", () => {
+  let ctx: TestContext;
+
+  const AUTH_TYPE: AuthType = "google";
+  const TEST_SEED_SHARE = "a".repeat(64) + "b".repeat(64);
+
+  let idTokenCounter = 0;
+  function nextIdToken(): string {
+    idTokenCounter++;
+    return `mock_token_ed25519_${idTokenCounter}`;
+  }
+
+  function nextUserId(): string {
+    idTokenCounter++;
+    return `ed25519_user_${idTokenCounter}`;
+  }
+
+  function generateSecp256k1Share(nodeIndex: number): string {
+    const prefix = "c";
+    const nodeHex = (nodeIndex + 1).toString(16).padStart(2, "0");
+    const pattern = `${prefix}${nodeHex}${prefix}`;
+    return pattern.repeat(32);
+  }
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+  });
+
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+
+  // ── Helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Create a secp256k1-only user via v1 keygen (registers on all KSN nodes).
+   */
+  async function prepareSecpOnlyUser(userId: string): Promise<{
+    secp256k1PublicKey: string;
+  }> {
+    const idToken = nextIdToken();
+    const secp256k1PublicKey = "03" + "a".repeat(64);
+
+    // Register secp256k1 to all KSN via v1
+    for (let i = 0; i < ctx.ksnApps.length; i++) {
+      const reg = await request(ctx.ksnApps[i])
+        .post("/keyshare/v1/register")
+        .set("x-mock-user-id", userId)
+        .set("Authorization", `Bearer ${idToken}`)
+        .send({
+          auth_type: AUTH_TYPE,
+          curve_type: "secp256k1",
+          public_key: secp256k1PublicKey,
+          share: generateSecp256k1Share(i),
+        });
+      expect(reg.status).toBe(200);
+    }
+
+    // v1 keygen on oko_api
+    const kg = await request(ctx.okoApiApp)
+      .post("/tss/v1/keygen")
+      .set("x-mock-user-id", userId)
+      .set("Authorization", `Bearer ${idToken}`)
+      .send({
+        auth_type: AUTH_TYPE,
+        keygen_2: {
+          public_key: secp256k1PublicKey,
+          private_share: "e".repeat(64),
+        },
+      });
+    expect(kg.status).toBe(200);
+
+    return { secp256k1PublicKey };
+  }
+
+  /**
+   * Register ed25519 on specified KSN node indices and call keygen_ed25519.
+   */
+  async function addEd25519OnNodes(
+    userId: string,
+    nodeIndices: number[],
+  ): Promise<{ status: number; body: any }> {
+    const idToken = nextIdToken();
+    const clientKeypair = generateClientKeypair();
+    const sessionId = generateSessionId();
+    const idHash = computeIdTokenHash(AUTH_TYPE, idToken);
+
+    const edKeygen = runKeygenCentralizedEd25519();
+    const edKeygen2 = edKeygen.keygen_outputs[1];
+    const edPkHex = Buffer.from(edKeygen.public_key).toString("hex");
+
+    // Commit to oko_api
+    const okoCommit = await request(ctx.okoApiApp).post("/tss/v2/commit").send({
+      session_id: sessionId,
+      operation_type: "add_ed25519",
+      client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+      id_token_hash: idHash,
+    });
+    expect(okoCommit.status).toBe(200);
+    const okoNodePk = okoCommit.body.data.node_pubkey;
+
+    // Commit + register ed25519 on specified nodes
+    for (const i of nodeIndices) {
+      const ksnCommit = await request(ctx.ksnApps[i])
+        .post("/keyshare/v2/commit")
+        .send({
+          session_id: sessionId,
+          operation_type: "add_ed25519",
+          client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+          id_token_hash: idHash,
+        });
+      expect(ksnCommit.status).toBe(200);
+
+      const regSig = createRevealSignature(
+        clientKeypair.privateKey,
+        ksnCommit.body.data.node_pubkey,
+        sessionId,
+        AUTH_TYPE,
+        idToken,
+        "add_ed25519",
+        "register_ed25519",
+      );
+
+      const reg = await request(ctx.ksnApps[i])
+        .post("/keyshare/v2/register/ed25519")
+        .set("x-mock-user-id", userId)
+        .set("Authorization", `Bearer ${idToken}`)
+        .send({
+          auth_type: AUTH_TYPE,
+          public_key: edPkHex,
+          share: (i === 0 ? "aa" : i === 1 ? "bb" : "cc").repeat(64),
+          seed_share: TEST_SEED_SHARE,
+          cr_session_id: sessionId,
+          cr_signature: regSig,
+        });
+      expect(reg.status).toBe(200);
+    }
+
+    // keygen_ed25519 on oko_api
+    const kgSig = createRevealSignature(
+      clientKeypair.privateKey,
+      okoNodePk,
+      sessionId,
+      AUTH_TYPE,
+      idToken,
+      "add_ed25519",
+      "keygen_ed25519",
+    );
+    const keygen = await request(ctx.okoApiApp)
+      .post("/tss/v2/keygen_ed25519")
+      .set("x-mock-user-id", userId)
+      .set("Authorization", `Bearer ${idToken}`)
+      .send({
+        auth_type: AUTH_TYPE,
+        keygen_2: {
+          key_package: edKeygen2.key_package,
+          public_key_package: Buffer.from(
+            edKeygen2.public_key_package,
+          ).toString("hex"),
+          identifier: edKeygen2.identifier,
+          public_key: edKeygen.public_key,
+          seed_share: TEST_SEED_SHARE,
+        },
+        cr_session_id: sessionId,
+        cr_signature: kgSig,
+      });
+
+    return { status: keygen.status, body: keygen.body };
+  }
+
+  async function getWalletKSNodeCount(walletId: string): Promise<number> {
+    const res = await ctx.okoApiPool.query(
+      `SELECT COUNT(*) as count FROM wallet_ks_nodes WHERE wallet_id = $1 AND status = 'ACTIVE'`,
+      [walletId],
+    );
+    return parseInt(res.rows[0].count, 10);
+  }
+
+  async function getUserEd25519WalletId(
+    userId: string,
+  ): Promise<string | null> {
+    const userRes = await ctx.okoApiPool.query(
+      `SELECT user_id FROM oko_users WHERE email = $1`,
+      [userId],
+    );
+    if (userRes.rows.length === 0) {
+      return null;
+    }
+    const walletsRes = await ctx.okoApiPool.query(
+      `SELECT wallet_id FROM oko_wallets WHERE user_id = $1 AND curve_type = 'ed25519' AND status = 'ACTIVE'`,
+      [userRes.rows[0].user_id],
+    );
+    return walletsRes.rows[0]?.wallet_id ?? null;
+  }
+
+  // ── Ed25519 keygen with registration_threshold ──────────────────────
+
+  describe("add_ed25519 with registration_threshold", () => {
+    it("ed25519 keygen succeeds with 2/3 nodes (threshold=2)", async () => {
+      await ctx.resetAllDatabases();
+      await ctx.okoApiPool.query(
+        `UPDATE key_share_node_meta SET registration_threshold = 2`,
+      );
+
+      const userId = nextUserId();
+      await prepareSecpOnlyUser(userId);
+
+      // Register ed25519 on nodes 0,1 only (node 2 "down")
+      const { status, body } = await addEd25519OnNodes(userId, [0, 1]);
+
+      expect(status).toBe(200);
+      expect(body.success).toBe(true);
+
+      // Verify ed25519 wallet created with 2 nodes
+      const ed25519WalletId = await getUserEd25519WalletId(userId);
+      expect(ed25519WalletId).not.toBeNull();
+      expect(await getWalletKSNodeCount(ed25519WalletId!)).toBe(2);
+    });
+
+    it("ed25519 keygen on all 3 nodes when all available", async () => {
+      await ctx.resetAllDatabases();
+      await ctx.okoApiPool.query(
+        `UPDATE key_share_node_meta SET registration_threshold = 2`,
+      );
+
+      const userId = nextUserId();
+      await prepareSecpOnlyUser(userId);
+
+      const { status, body } = await addEd25519OnNodes(userId, [0, 1, 2]);
+
+      expect(status).toBe(200);
+      expect(body.success).toBe(true);
+
+      const ed25519WalletId = await getUserEd25519WalletId(userId);
+      expect(ed25519WalletId).not.toBeNull();
+      expect(await getWalletKSNodeCount(ed25519WalletId!)).toBe(3);
+    });
+  });
+
+  // ── Ed25519 keygen → reshare recovery ───────────────────────────────
+
+  describe("add_ed25519 partial → reshare recovery", () => {
+    it("ed25519 on 2/3 → reshare to all 3 → wallet_ks_nodes expanded", async () => {
+      await ctx.resetAllDatabases();
+      await ctx.okoApiPool.query(
+        `UPDATE key_share_node_meta SET registration_threshold = 2`,
+      );
+
+      const userId = nextUserId();
+      const { secp256k1PublicKey } = await prepareSecpOnlyUser(userId);
+
+      // Step 1: ed25519 keygen on 2/3 nodes
+      const { status: edStatus } = await addEd25519OnNodes(userId, [0, 1]);
+      expect(edStatus).toBe(200);
+
+      const ed25519WalletId = await getUserEd25519WalletId(userId);
+      expect(ed25519WalletId).not.toBeNull();
+      expect(await getWalletKSNodeCount(ed25519WalletId!)).toBe(2);
+
+      // Step 2: Get ed25519 public key from DB
+      const walletRes = await ctx.okoApiPool.query(
+        `SELECT encode(public_key, 'hex') as pk_hex FROM oko_wallets WHERE wallet_id = $1`,
+        [ed25519WalletId],
+      );
+      const ed25519PublicKeyHex = walletRes.rows[0].pk_hex;
+
+      // Step 3: Reshare to all 3 nodes (node 2 recovered)
+      const reshareIdToken = nextIdToken();
+      const reshareKeypair = generateClientKeypair();
+      const reshareSessionId = generateSessionId();
+      const reshareIdHash = computeIdTokenHash(AUTH_TYPE, reshareIdToken);
+
+      const okoCommit = await request(ctx.okoApiApp)
+        .post("/tss/v2/commit")
+        .send({
+          session_id: reshareSessionId,
+          operation_type: "reshare",
+          client_ephemeral_pubkey: reshareKeypair.publicKey.toHex(),
+          id_token_hash: reshareIdHash,
+        });
+      expect(okoCommit.status).toBe(200);
+      const okoNodePk = okoCommit.body.data.node_pubkey;
+
+      // Signin
+      const signinSig = createRevealSignature(
+        reshareKeypair.privateKey,
+        okoNodePk,
+        reshareSessionId,
+        AUTH_TYPE,
+        reshareIdToken,
+        "reshare",
+        "signin",
+      );
+      const signin = await request(ctx.okoApiApp)
+        .post("/tss/v2/user/signin")
+        .set("x-mock-user-id", userId)
+        .set("Authorization", `Bearer ${reshareIdToken}`)
+        .send({
+          auth_type: AUTH_TYPE,
+          cr_session_id: reshareSessionId,
+          cr_signature: signinSig,
+        });
+      expect(signin.status).toBe(200);
+
+      // Reshare on all 3 KSN nodes
+      const resharedNodes: Array<{ name: string; endpoint: string }> = [];
+      for (let i = 0; i < ctx.ksnApps.length; i++) {
+        const ksnCommit = await request(ctx.ksnApps[i])
+          .post("/keyshare/v2/commit")
+          .send({
+            session_id: reshareSessionId,
+            operation_type: "reshare",
+            client_ephemeral_pubkey: reshareKeypair.publicKey.toHex(),
+            id_token_hash: reshareIdHash,
+          });
+        expect(ksnCommit.status).toBe(200);
+
+        const sig = createRevealSignature(
+          reshareKeypair.privateKey,
+          ksnCommit.body.data.node_pubkey,
+          reshareSessionId,
+          AUTH_TYPE,
+          reshareIdToken,
+          "reshare",
+          "reshare",
+        );
+
+        const res = await request(ctx.ksnApps[i])
+          .post("/keyshare/v2/reshare")
+          .set("x-mock-user-id", userId)
+          .set("Authorization", `Bearer ${reshareIdToken}`)
+          .send({
+            auth_type: AUTH_TYPE,
+            wallets: {
+              secp256k1: {
+                public_key: secp256k1PublicKey,
+                share: generateSecp256k1Share(i),
+              },
+              ed25519: {
+                public_key: ed25519PublicKeyHex,
+                share: (i === 0 ? "aa" : i === 1 ? "bb" : "cc").repeat(64),
+                seed_share: TEST_SEED_SHARE,
+              },
+            },
+            cr_session_id: reshareSessionId,
+            cr_signature: sig,
+          });
+        expect(res.status).toBe(200);
+
+        resharedNodes.push({
+          name: `test_node_${i + 1}`,
+          endpoint: ctx.ksnUrls[i],
+        });
+      }
+
+      // Update oko_api
+      const reshareSig = createRevealSignature(
+        reshareKeypair.privateKey,
+        okoNodePk,
+        reshareSessionId,
+        AUTH_TYPE,
+        reshareIdToken,
+        "reshare",
+        "reshare",
+      );
+      const okoReshare = await request(ctx.okoApiApp)
+        .post("/tss/v2/user/reshare")
+        .set("x-mock-user-id", userId)
+        .set("Authorization", `Bearer ${reshareIdToken}`)
+        .send({
+          auth_type: AUTH_TYPE,
+          secp256k1_public_key: secp256k1PublicKey,
+          ed25519_public_key: ed25519PublicKeyHex,
+          reshared_key_shares: resharedNodes,
+          cr_session_id: reshareSessionId,
+          cr_signature: reshareSig,
+        });
+      expect(okoReshare.status).toBe(200);
+
+      // Verify: ed25519 wallet now has 3 nodes
+      expect(await getWalletKSNodeCount(ed25519WalletId!)).toBe(3);
+    });
+  });
+
+  // ── PendingCommits: all nodes alive, threshold < nodes.length ──────
+
+  describe("pendingCommits resolve (all nodes alive)", () => {
+    it("sign_up with threshold=2 registers all 3 nodes when all alive", async () => {
+      await ctx.resetAllDatabases();
+      await ctx.okoApiPool.query(
+        `UPDATE key_share_node_meta SET registration_threshold = 2`,
+      );
+
+      const userId = nextUserId();
+      const idToken = nextIdToken();
+
+      // Full v2 sign_up flow
+      const edKeygen = runKeygenCentralizedEd25519();
+      const edKeygen2 = edKeygen.keygen_outputs[1];
+      const secp256k1PublicKey = "03" + "b".repeat(64);
+      const ed25519PublicKeyHex = Buffer.from(edKeygen.public_key).toString(
+        "hex",
+      );
+
+      const clientKeypair = generateClientKeypair();
+      const sessionId = generateSessionId();
+      const idHash = computeIdTokenHash(AUTH_TYPE, idToken);
+
+      // Commit oko_api
+      const okoCommit = await request(ctx.okoApiApp)
+        .post("/tss/v2/commit")
+        .send({
+          session_id: sessionId,
+          operation_type: "sign_up",
+          client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+          id_token_hash: idHash,
+        });
+      expect(okoCommit.status).toBe(200);
+      const okoNodePk = okoCommit.body.data.node_pubkey;
+
+      // Commit + register on ALL 3 KSN nodes
+      for (let i = 0; i < ctx.ksnApps.length; i++) {
+        const ksnCommit = await request(ctx.ksnApps[i])
+          .post("/keyshare/v2/commit")
+          .send({
+            session_id: sessionId,
+            operation_type: "sign_up",
+            client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+            id_token_hash: idHash,
+          });
+        expect(ksnCommit.status).toBe(200);
+
+        const regSig = createRevealSignature(
+          clientKeypair.privateKey,
+          ksnCommit.body.data.node_pubkey,
+          sessionId,
+          AUTH_TYPE,
+          idToken,
+          "sign_up",
+          "register",
+        );
+
+        const reg = await request(ctx.ksnApps[i])
+          .post("/keyshare/v2/register")
+          .set("x-mock-user-id", userId)
+          .set("Authorization", `Bearer ${idToken}`)
+          .send({
+            auth_type: AUTH_TYPE,
+            wallets: {
+              secp256k1: {
+                public_key: secp256k1PublicKey,
+                share: generateSecp256k1Share(i),
+              },
+              ed25519: {
+                public_key: ed25519PublicKeyHex,
+                share: (i === 0 ? "aa" : i === 1 ? "bb" : "cc").repeat(64),
+                seed_share: TEST_SEED_SHARE,
+              },
+            },
+            cr_session_id: sessionId,
+            cr_signature: regSig,
+          });
+        expect(reg.status).toBe(200);
+      }
+
+      // Keygen on oko_api
+      const kgSig = createRevealSignature(
+        clientKeypair.privateKey,
+        okoNodePk,
+        sessionId,
+        AUTH_TYPE,
+        idToken,
+        "sign_up",
+        "keygen",
+      );
+      const keygen = await request(ctx.okoApiApp)
+        .post("/tss/v2/keygen")
+        .set("x-mock-user-id", userId)
+        .set("Authorization", `Bearer ${idToken}`)
+        .send({
+          auth_type: AUTH_TYPE,
+          keygen_2_secp256k1: {
+            public_key: secp256k1PublicKey,
+            private_share: "e".repeat(64),
+          },
+          keygen_2_ed25519: {
+            key_package: edKeygen2.key_package,
+            public_key_package: Buffer.from(
+              edKeygen2.public_key_package,
+            ).toString("hex"),
+            identifier: edKeygen2.identifier,
+            public_key: edKeygen.public_key,
+          },
+          ed25519_seed_share: TEST_SEED_SHARE,
+          cr_session_id: sessionId,
+          cr_signature: kgSig,
+        });
+      expect(keygen.status).toBe(200);
+      expect(keygen.body.success).toBe(true);
+
+      // Verify: ALL 3 nodes registered (not just threshold=2)
+      const userRes = await ctx.okoApiPool.query(
+        `SELECT user_id FROM oko_users WHERE email = $1`,
+        [userId],
+      );
+      const walletsRes = await ctx.okoApiPool.query(
+        `SELECT wallet_id, curve_type FROM oko_wallets WHERE user_id = $1 AND status = 'ACTIVE'`,
+        [userRes.rows[0].user_id],
+      );
+      for (const wallet of walletsRes.rows) {
+        const count = await getWalletKSNodeCount(wallet.wallet_id);
+        expect(count).toBe(3);
+      }
+    });
+  });
+
+  // ── Null threshold fallback ─────────────────────────────────────────
+
+  describe("null registration_threshold (all-or-nothing)", () => {
+    it("ed25519 keygen with all 3 nodes succeeds when threshold is null", async () => {
+      await ctx.resetAllDatabases();
+      // Default: registration_threshold = null
+
+      const userId = nextUserId();
+      await prepareSecpOnlyUser(userId);
+
+      const { status, body } = await addEd25519OnNodes(userId, [0, 1, 2]);
+
+      expect(status).toBe(200);
+      expect(body.success).toBe(true);
+
+      const ed25519WalletId = await getUserEd25519WalletId(userId);
+      expect(ed25519WalletId).not.toBeNull();
+      expect(await getWalletKSNodeCount(ed25519WalletId!)).toBe(3);
+    });
+  });
+});

--- a/e2e_tests/src/__tests__/scenarios/registration_threshold_reshare.test.ts
+++ b/e2e_tests/src/__tests__/scenarios/registration_threshold_reshare.test.ts
@@ -1,0 +1,620 @@
+import {
+  computeIdTokenHash,
+  createRevealSignature,
+  generateClientKeypair,
+  generateSessionId,
+} from "@e2e/utils/signature";
+import { createTestContext, type TestContext } from "@e2e/utils/test_context";
+import type { AuthType } from "@oko-wallet/oko-types/auth";
+import {
+  extractKeyPackageSharesEd25519,
+  runKeygenCentralizedEd25519,
+  sssSplitEd25519,
+} from "@oko-wallet/teddsa-addon/src/server";
+import request from "supertest";
+
+/**
+ * Scenario tests for registration_threshold + reshare partial success.
+ *
+ * Tests the full end-to-end flow with real KSN servers:
+ * - Sign-up with partial node registration (some nodes "down")
+ * - Reshare with partial nodes
+ * - Reshare after node recovery
+ * - checkEmailV2 responses with registration_threshold
+ * - Wallet KS node state transitions across signup → reshare cycles
+ */
+describe("e2e_test_registration_threshold_reshare", () => {
+  let ctx: TestContext;
+
+  const TEST_USER_ID = "reg_threshold_user";
+  const AUTH_TYPE: AuthType = "google";
+  const TEST_SEED_SHARE = "a".repeat(64) + "b".repeat(64);
+
+  let idTokenCounter = 0;
+  function nextIdToken(): string {
+    idTokenCounter++;
+    return `mock_token_${idTokenCounter}`;
+  }
+
+  function generateNodeIdentifier(nodeIndex: number): Uint8Array {
+    const id = new Uint8Array(32);
+    id[0] = nodeIndex + 10;
+    return id;
+  }
+
+  function generateSecp256k1Share(nodeIndex: number): string {
+    const prefix = "c";
+    const nodeHex = (nodeIndex + 1).toString(16).padStart(2, "0");
+    const pattern = `${prefix}${nodeHex}${prefix}`;
+    return pattern.repeat(32);
+  }
+
+  beforeAll(async () => {
+    ctx = await createTestContext();
+  });
+
+  afterAll(async () => {
+    await ctx.cleanup();
+  });
+
+  // ── Helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Register user on first `nodeCount` KSN nodes and run oko_api keygen.
+   */
+  async function signUpOnNodes(nodeCount: number): Promise<{
+    secp256k1PublicKey: string;
+    ed25519PublicKeyHex: string;
+    nodeShares: Array<{ secp256k1Share: string; ed25519Share: string }>;
+  }> {
+    const idToken = nextIdToken();
+    const clientKeypair = generateClientKeypair();
+    const sessionId = generateSessionId();
+    const idTokenHash = computeIdTokenHash(AUTH_TYPE, idToken);
+
+    const frostKeygen = runKeygenCentralizedEd25519();
+    const clientOut = frostKeygen.keygen_outputs[0];
+    const serverOut = frostKeygen.keygen_outputs[1];
+    const clientKeyPackage = new Uint8Array(clientOut.key_package);
+    const clientShares = extractKeyPackageSharesEd25519(clientKeyPackage);
+    const ed25519Pk = frostKeygen.public_key;
+    const ed25519PublicKeyHex = Buffer.from(ed25519Pk).toString("hex");
+    const secp256k1PublicKey = "03" + "a".repeat(64);
+
+    const signingShare = new Uint8Array(clientShares.signing_share);
+    const nodeIdentifiers = [
+      generateNodeIdentifier(0),
+      generateNodeIdentifier(1),
+      generateNodeIdentifier(2),
+    ];
+    const sss = sssSplitEd25519(signingShare, nodeIdentifiers, 2);
+
+    // Commit to oko_api
+    const okoCommit = await request(ctx.okoApiApp).post("/tss/v2/commit").send({
+      session_id: sessionId,
+      operation_type: "sign_up",
+      client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+      id_token_hash: idTokenHash,
+    });
+    expect(okoCommit.status).toBe(200);
+    const okoNodePk = okoCommit.body.data.node_pubkey;
+
+    // Register on first `nodeCount` KSN nodes
+    const nodeShares: Array<{
+      secp256k1Share: string;
+      ed25519Share: string;
+    }> = [];
+    for (let i = 0; i < nodeCount; i++) {
+      const ksnCommit = await request(ctx.ksnApps[i])
+        .post("/keyshare/v2/commit")
+        .send({
+          session_id: sessionId,
+          operation_type: "sign_up",
+          client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+          id_token_hash: idTokenHash,
+        });
+      expect(ksnCommit.status).toBe(200);
+
+      const kpBytes = new Uint8Array(sss.key_packages[i].key_package);
+      const shares = extractKeyPackageSharesEd25519(kpBytes);
+      const edShare =
+        Buffer.from(shares.signing_share).toString("hex") +
+        Buffer.from(shares.verifying_share).toString("hex");
+
+      nodeShares[i] = {
+        secp256k1Share: generateSecp256k1Share(i),
+        ed25519Share: edShare,
+      };
+
+      const regSig = createRevealSignature(
+        clientKeypair.privateKey,
+        ksnCommit.body.data.node_pubkey,
+        sessionId,
+        AUTH_TYPE,
+        idToken,
+        "sign_up",
+        "register",
+      );
+
+      const reg = await request(ctx.ksnApps[i])
+        .post("/keyshare/v2/register")
+        .set("x-mock-user-id", TEST_USER_ID)
+        .set("Authorization", `Bearer ${idToken}`)
+        .send({
+          auth_type: AUTH_TYPE,
+          wallets: {
+            secp256k1: {
+              public_key: secp256k1PublicKey,
+              share: nodeShares[i].secp256k1Share,
+            },
+            ed25519: {
+              public_key: ed25519PublicKeyHex,
+              share: nodeShares[i].ed25519Share,
+              seed_share: TEST_SEED_SHARE,
+            },
+          },
+          cr_session_id: sessionId,
+          cr_signature: regSig,
+        });
+      expect(reg.status).toBe(200);
+    }
+
+    // Also store placeholder shares for unregistered nodes (for reshare later)
+    for (let i = nodeCount; i < 3; i++) {
+      const kpBytes = new Uint8Array(sss.key_packages[i].key_package);
+      const shares = extractKeyPackageSharesEd25519(kpBytes);
+      const edShare =
+        Buffer.from(shares.signing_share).toString("hex") +
+        Buffer.from(shares.verifying_share).toString("hex");
+      nodeShares[i] = {
+        secp256k1Share: generateSecp256k1Share(i),
+        ed25519Share: edShare,
+      };
+    }
+
+    // oko_api keygen
+    const kgSig = createRevealSignature(
+      clientKeypair.privateKey,
+      okoNodePk,
+      sessionId,
+      AUTH_TYPE,
+      idToken,
+      "sign_up",
+      "keygen",
+    );
+    const kg = await request(ctx.okoApiApp)
+      .post("/tss/v2/keygen")
+      .set("x-mock-user-id", TEST_USER_ID)
+      .set("Authorization", `Bearer ${idToken}`)
+      .send({
+        auth_type: AUTH_TYPE,
+        keygen_2_secp256k1: {
+          public_key: secp256k1PublicKey,
+          private_share: "e".repeat(64),
+        },
+        keygen_2_ed25519: {
+          key_package: serverOut.key_package,
+          public_key_package: Buffer.from(
+            serverOut.public_key_package,
+          ).toString("hex"),
+          identifier: serverOut.identifier,
+          public_key: ed25519Pk,
+        },
+        ed25519_seed_share: TEST_SEED_SHARE,
+        cr_session_id: sessionId,
+        cr_signature: kgSig,
+      });
+    expect(kg.status).toBe(200);
+
+    return { secp256k1PublicKey, ed25519PublicKeyHex, nodeShares };
+  }
+
+  /**
+   * Run reshare on specified KSN node indices, then update oko_api.
+   */
+  async function reshareOnNodes(
+    nodeIndices: number[],
+    secp256k1PublicKey: string,
+    ed25519PublicKeyHex: string,
+    nodeShares: Array<{ secp256k1Share: string; ed25519Share: string }>,
+  ): Promise<{ status: number; body: any }> {
+    const idToken = nextIdToken();
+    const clientKeypair = generateClientKeypair();
+    const sessionId = generateSessionId();
+    const idHash = computeIdTokenHash(AUTH_TYPE, idToken);
+
+    const okoCommit = await request(ctx.okoApiApp).post("/tss/v2/commit").send({
+      session_id: sessionId,
+      operation_type: "reshare",
+      client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+      id_token_hash: idHash,
+    });
+    expect(okoCommit.status).toBe(200);
+    const okoNodePk = okoCommit.body.data.node_pubkey;
+
+    // Signin
+    const signinSig = createRevealSignature(
+      clientKeypair.privateKey,
+      okoNodePk,
+      sessionId,
+      AUTH_TYPE,
+      idToken,
+      "reshare",
+      "signin",
+    );
+    const signin = await request(ctx.okoApiApp)
+      .post("/tss/v2/user/signin")
+      .set("x-mock-user-id", TEST_USER_ID)
+      .set("Authorization", `Bearer ${idToken}`)
+      .send({
+        auth_type: AUTH_TYPE,
+        cr_session_id: sessionId,
+        cr_signature: signinSig,
+      });
+    expect(signin.status).toBe(200);
+
+    // Reshare on specified KSN nodes
+    const resharedNodes: Array<{ name: string; endpoint: string }> = [];
+    for (const i of nodeIndices) {
+      const ksnCommit = await request(ctx.ksnApps[i])
+        .post("/keyshare/v2/commit")
+        .send({
+          session_id: sessionId,
+          operation_type: "reshare",
+          client_ephemeral_pubkey: clientKeypair.publicKey.toHex(),
+          id_token_hash: idHash,
+        });
+      expect(ksnCommit.status).toBe(200);
+
+      const sig = createRevealSignature(
+        clientKeypair.privateKey,
+        ksnCommit.body.data.node_pubkey,
+        sessionId,
+        AUTH_TYPE,
+        idToken,
+        "reshare",
+        "reshare",
+      );
+
+      const res = await request(ctx.ksnApps[i])
+        .post("/keyshare/v2/reshare")
+        .set("x-mock-user-id", TEST_USER_ID)
+        .set("Authorization", `Bearer ${idToken}`)
+        .send({
+          auth_type: AUTH_TYPE,
+          wallets: {
+            secp256k1: {
+              public_key: secp256k1PublicKey,
+              share: nodeShares[i].secp256k1Share,
+            },
+            ed25519: {
+              public_key: ed25519PublicKeyHex,
+              share: nodeShares[i].ed25519Share,
+              seed_share: TEST_SEED_SHARE,
+            },
+          },
+          cr_session_id: sessionId,
+          cr_signature: sig,
+        });
+      expect(res.status).toBe(200);
+
+      resharedNodes.push({
+        name: `test_node_${i + 1}`,
+        endpoint: ctx.ksnUrls[i],
+      });
+    }
+
+    // Update oko_api
+    const reshareSig = createRevealSignature(
+      clientKeypair.privateKey,
+      okoNodePk,
+      sessionId,
+      AUTH_TYPE,
+      idToken,
+      "reshare",
+      "reshare",
+    );
+    const okoReshare = await request(ctx.okoApiApp)
+      .post("/tss/v2/user/reshare")
+      .set("x-mock-user-id", TEST_USER_ID)
+      .set("Authorization", `Bearer ${idToken}`)
+      .send({
+        auth_type: AUTH_TYPE,
+        secp256k1_public_key: secp256k1PublicKey,
+        ed25519_public_key: ed25519PublicKeyHex,
+        reshared_key_shares: resharedNodes,
+        cr_session_id: sessionId,
+        cr_signature: reshareSig,
+      });
+
+    return { status: okoReshare.status, body: okoReshare.body };
+  }
+
+  async function getWalletKSNodeCount(walletId: string): Promise<number> {
+    const res = await ctx.okoApiPool.query(
+      `SELECT COUNT(*) as count FROM wallet_ks_nodes WHERE wallet_id = $1 AND status = 'ACTIVE'`,
+      [walletId],
+    );
+    return parseInt(res.rows[0].count, 10);
+  }
+
+  async function getWalletKSNodeIds(walletId: string): Promise<string[]> {
+    const res = await ctx.okoApiPool.query(
+      `SELECT node_id FROM wallet_ks_nodes WHERE wallet_id = $1 AND status = 'ACTIVE' ORDER BY node_id`,
+      [walletId],
+    );
+    return res.rows.map((r: any) => r.node_id);
+  }
+
+  async function getUserWalletIds(): Promise<{
+    secp256k1WalletId: string;
+    ed25519WalletId: string;
+  }> {
+    const userRes = await ctx.okoApiPool.query(
+      `SELECT user_id FROM oko_users WHERE email = $1`,
+      [TEST_USER_ID],
+    );
+    const userId = userRes.rows[0].user_id;
+    const walletsRes = await ctx.okoApiPool.query(
+      `SELECT wallet_id, curve_type FROM oko_wallets WHERE user_id = $1 AND status = 'ACTIVE'`,
+      [userId],
+    );
+    const secp = walletsRes.rows.find((r: any) => r.curve_type === "secp256k1");
+    const ed = walletsRes.rows.find((r: any) => r.curve_type === "ed25519");
+    return {
+      secp256k1WalletId: secp.wallet_id,
+      ed25519WalletId: ed.wallet_id,
+    };
+  }
+
+  async function getKsnNodeIds(): Promise<string[]> {
+    const res = await ctx.okoApiPool.query(
+      `SELECT node_id FROM key_share_nodes WHERE status = 'ACTIVE' ORDER BY node_name`,
+    );
+    return res.rows.map((r: any) => r.node_id);
+  }
+
+  // ── checkEmailV2 ────────────────────────────────────────────────────
+
+  describe("checkEmailV2 with registration_threshold", () => {
+    it("returns registration_threshold in keyshare_node_meta response", async () => {
+      await ctx.resetAllDatabases();
+      await ctx.okoApiPool.query(
+        `UPDATE key_share_node_meta SET registration_threshold = 2`,
+      );
+
+      const res = await request(ctx.okoApiApp)
+        .post("/tss/v2/user/check")
+        .send({ email: "check@example.com", auth_type: AUTH_TYPE });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.keyshare_node_meta.registration_threshold).toBe(2);
+    });
+
+    it("returns null registration_threshold when not set", async () => {
+      await ctx.resetAllDatabases();
+
+      const res = await request(ctx.okoApiApp)
+        .post("/tss/v2/user/check")
+        .send({ email: "check@example.com", auth_type: AUTH_TYPE });
+
+      expect(res.status).toBe(200);
+      expect(
+        res.body.data.keyshare_node_meta.registration_threshold,
+      ).toBeNull();
+    });
+  });
+
+  // ── Sign-up partial success ─────────────────────────────────────────
+
+  describe("sign-up with registration_threshold", () => {
+    it("succeeds when registered nodes >= registration_threshold", async () => {
+      await ctx.resetAllDatabases();
+      await ctx.okoApiPool.query(
+        `UPDATE key_share_node_meta SET registration_threshold = 2`,
+      );
+
+      await signUpOnNodes(2);
+
+      const walletIds = await getUserWalletIds();
+      expect(await getWalletKSNodeCount(walletIds.secp256k1WalletId)).toBe(2);
+      expect(await getWalletKSNodeCount(walletIds.ed25519WalletId)).toBe(2);
+    });
+
+    it("registers all 3 nodes when all are available", async () => {
+      await ctx.resetAllDatabases();
+      await ctx.okoApiPool.query(
+        `UPDATE key_share_node_meta SET registration_threshold = 2`,
+      );
+
+      await signUpOnNodes(3);
+
+      const walletIds = await getUserWalletIds();
+      expect(await getWalletKSNodeCount(walletIds.secp256k1WalletId)).toBe(3);
+      expect(await getWalletKSNodeCount(walletIds.ed25519WalletId)).toBe(3);
+    });
+
+    it("wallet_ks_nodes only contains registered nodes (not all active nodes)", async () => {
+      await ctx.resetAllDatabases();
+      await ctx.okoApiPool.query(
+        `UPDATE key_share_node_meta SET registration_threshold = 2`,
+      );
+
+      await signUpOnNodes(2);
+
+      const walletIds = await getUserWalletIds();
+      const ksnNodeIds = await getKsnNodeIds();
+      const walletNodeIds = await getWalletKSNodeIds(
+        walletIds.secp256k1WalletId,
+      );
+
+      // Only 2 of 3 nodes should be in wallet_ks_nodes
+      expect(walletNodeIds.length).toBe(2);
+      expect(ksnNodeIds.length).toBe(3);
+      // The registered nodes should be a subset of all KSN nodes
+      for (const nodeId of walletNodeIds) {
+        expect(ksnNodeIds).toContain(nodeId);
+      }
+    });
+  });
+
+  // ── Reshare after partial sign-up ───────────────────────────────────
+
+  describe("reshare after partial sign-up (node 2 was down)", () => {
+    let secp256k1PublicKey: string;
+    let ed25519PublicKeyHex: string;
+    let nodeShares: Array<{ secp256k1Share: string; ed25519Share: string }>;
+    let walletIds: { secp256k1WalletId: string; ed25519WalletId: string };
+
+    beforeEach(async () => {
+      await ctx.resetAllDatabases();
+      await ctx.okoApiPool.query(
+        `UPDATE key_share_node_meta SET registration_threshold = 2`,
+      );
+
+      const result = await signUpOnNodes(2);
+      secp256k1PublicKey = result.secp256k1PublicKey;
+      ed25519PublicKeyHex = result.ed25519PublicKeyHex;
+      nodeShares = result.nodeShares;
+      walletIds = await getUserWalletIds();
+    });
+
+    it("reshare to nodes 0,1 only (node 2 still down) — wallet_ks_nodes stays 2", async () => {
+      const { status, body } = await reshareOnNodes(
+        [0, 1],
+        secp256k1PublicKey,
+        ed25519PublicKeyHex,
+        nodeShares,
+      );
+
+      expect(status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(await getWalletKSNodeCount(walletIds.secp256k1WalletId)).toBe(2);
+      expect(await getWalletKSNodeCount(walletIds.ed25519WalletId)).toBe(2);
+    });
+
+    it("reshare to all 3 nodes (node 2 recovered) — wallet_ks_nodes expands to 3", async () => {
+      const { status, body } = await reshareOnNodes(
+        [0, 1, 2],
+        secp256k1PublicKey,
+        ed25519PublicKeyHex,
+        nodeShares,
+      );
+
+      expect(status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(await getWalletKSNodeCount(walletIds.secp256k1WalletId)).toBe(3);
+      expect(await getWalletKSNodeCount(walletIds.ed25519WalletId)).toBe(3);
+    });
+
+    it("reshare twice: first partial, then full recovery", async () => {
+      // First reshare: node 2 still down → only 0,1
+      const first = await reshareOnNodes(
+        [0, 1],
+        secp256k1PublicKey,
+        ed25519PublicKeyHex,
+        nodeShares,
+      );
+      expect(first.status).toBe(200);
+      expect(await getWalletKSNodeCount(walletIds.secp256k1WalletId)).toBe(2);
+
+      // Second reshare: node 2 recovered → all 3
+      const second = await reshareOnNodes(
+        [0, 1, 2],
+        secp256k1PublicKey,
+        ed25519PublicKeyHex,
+        nodeShares,
+      );
+      expect(second.status).toBe(200);
+      expect(await getWalletKSNodeCount(walletIds.secp256k1WalletId)).toBe(3);
+      expect(await getWalletKSNodeCount(walletIds.ed25519WalletId)).toBe(3);
+    });
+
+    it("both secp256k1 and ed25519 wallet_ks_nodes are consistent after reshare", async () => {
+      const { status } = await reshareOnNodes(
+        [0, 1, 2],
+        secp256k1PublicKey,
+        ed25519PublicKeyHex,
+        nodeShares,
+      );
+      expect(status).toBe(200);
+
+      const secpNodeIds = await getWalletKSNodeIds(walletIds.secp256k1WalletId);
+      const edNodeIds = await getWalletKSNodeIds(walletIds.ed25519WalletId);
+      expect(secpNodeIds).toEqual(edNodeIds);
+    });
+  });
+
+  // ── Reshare after full sign-up (node goes down later) ──────────────
+
+  describe("reshare after full sign-up (3/3, then node 2 goes down)", () => {
+    let secp256k1PublicKey: string;
+    let ed25519PublicKeyHex: string;
+    let nodeShares: Array<{ secp256k1Share: string; ed25519Share: string }>;
+    let walletIds: { secp256k1WalletId: string; ed25519WalletId: string };
+
+    beforeEach(async () => {
+      await ctx.resetAllDatabases();
+      await ctx.okoApiPool.query(
+        `UPDATE key_share_node_meta SET registration_threshold = 2`,
+      );
+
+      const result = await signUpOnNodes(3);
+      secp256k1PublicKey = result.secp256k1PublicKey;
+      ed25519PublicKeyHex = result.ed25519PublicKeyHex;
+      nodeShares = result.nodeShares;
+      walletIds = await getUserWalletIds();
+    });
+
+    it("started with 3 nodes registered", async () => {
+      expect(await getWalletKSNodeCount(walletIds.secp256k1WalletId)).toBe(3);
+    });
+
+    it("reshare to 0,1 only (node 2 down) — existing node 2 record preserved via upsert", async () => {
+      const { status, body } = await reshareOnNodes(
+        [0, 1],
+        secp256k1PublicKey,
+        ed25519PublicKeyHex,
+        nodeShares,
+      );
+
+      expect(status).toBe(200);
+      expect(body.success).toBe(true);
+
+      // upsert only touches nodes 0,1; node 2's existing record stays
+      const count = await getWalletKSNodeCount(walletIds.secp256k1WalletId);
+      expect(count).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // ── Null threshold fallback ─────────────────────────────────────────
+
+  describe("null registration_threshold (all-or-nothing fallback)", () => {
+    it("sign-up with all 3 nodes succeeds when threshold is null", async () => {
+      await ctx.resetAllDatabases();
+      // Default seed has registration_threshold = null
+
+      await signUpOnNodes(3);
+
+      const walletIds = await getUserWalletIds();
+      expect(await getWalletKSNodeCount(walletIds.secp256k1WalletId)).toBe(3);
+    });
+
+    it("reshare with all 3 nodes succeeds when threshold is null", async () => {
+      await ctx.resetAllDatabases();
+
+      const { secp256k1PublicKey, ed25519PublicKeyHex, nodeShares } =
+        await signUpOnNodes(3);
+
+      const { status, body } = await reshareOnNodes(
+        [0, 1, 2],
+        secp256k1PublicKey,
+        ed25519PublicKeyHex,
+        nodeShares,
+      );
+
+      expect(status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+  });
+});

--- a/e2e_tests/src/setup/database.ts
+++ b/e2e_tests/src/setup/database.ts
@@ -160,6 +160,7 @@ export async function initializeOkoApiSchema(pool: Pool): Promise<void> {
     CREATE TABLE IF NOT EXISTS key_share_node_meta (
       meta_id uuid DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
       sss_threshold int2 NOT NULL,
+      registration_threshold int2 NULL,
       created_at timestamptz DEFAULT now() NOT NULL,
       updated_at timestamptz DEFAULT now() NOT NULL
     );
@@ -186,6 +187,10 @@ export async function initializeOkoApiSchema(pool: Pool): Promise<void> {
     -- Ensure status column exists on oko_users
     ALTER TABLE oko_users
       ADD COLUMN IF NOT EXISTS status varchar(32) DEFAULT 'ACTIVE' NOT NULL;
+
+    -- Ensure registration_threshold column exists on key_share_node_meta
+    ALTER TABLE key_share_node_meta
+      ADD COLUMN IF NOT EXISTS registration_threshold int2 NULL;
   `);
 }
 

--- a/embed/oko_attached/src/crypto/commit_reveal/session.ts
+++ b/embed/oko_attached/src/crypto/commit_reveal/session.ts
@@ -74,6 +74,48 @@ export function setKsnNodePubkey(
   };
 }
 
+const PENDING_COMMIT_TIMEOUT_MS = 5000;
+
+/**
+ * Resolve remaining pending commits with a timeout, updating the session
+ * with each successfully committed node's pubkey.
+ *
+ * Pending promises are already in-flight from commitAll. This function
+ * awaits them concurrently (bounded by the timeout) so that all reachable
+ * nodes get registered in the session for downstream register/reshare.
+ *
+ * Down nodes (ECONNREFUSED) fail instantly. Blackholed nodes are skipped
+ * after the timeout instead of blocking until browser TCP timeout.
+ */
+export async function resolvePendingCommits(
+  session: ClientCommitRevealSession,
+  pendingCommits: Map<string, Promise<KsnCommitResult>>,
+): Promise<ClientCommitRevealSession> {
+  let updated = session;
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(
+      () => reject(new Error("pending_commit_timeout")),
+      PENDING_COMMIT_TIMEOUT_MS,
+    ),
+  );
+
+  for (const [, promise] of pendingCommits) {
+    try {
+      const result = await Promise.race([promise, timeout]);
+      updated = setKsnNodePubkey(
+        updated,
+        result.nodeUrl,
+        result.nodePubkey,
+        result.operationType,
+      );
+    } catch {
+      // Node failed or timed out — skip
+    }
+  }
+
+  return updated;
+}
+
 /**
  * Commit to oko_api and ks nodes with threshold-based early return.
  *

--- a/embed/oko_attached/src/crypto/reshare_v2.ts
+++ b/embed/oko_attached/src/crypto/reshare_v2.ts
@@ -148,8 +148,11 @@ export async function reshareUserKeySharesV2(
   secp256k1: ReshareWalletInfoSecp256k1,
   ed25519: ReshareWalletInfoEd25519,
   session: ClientCommitRevealSession,
+  committedNodeEndpoints?: string[],
 ): Promise<Result<ReshareV2Result, string>> {
   const { threshold, nodes } = keyshareNodeMeta;
+  const registrationThreshold =
+    keyshareNodeMeta.registration_threshold ?? nodes.length;
 
   // 1. Classify nodes by unified status
   const activeNodes = nodes.filter((n) => n.wallet_status === "ACTIVE");
@@ -232,12 +235,15 @@ export async function reshareUserKeySharesV2(
     originalSecret: [...seedExpandRes.data.original_secret.toUint8Array()],
   };
 
-  // 5. Send new shares to ALL nodes
-  const allNodes = nodes;
+  // 5. Send new shares to committed nodes (partial success allowed)
+  // Only send to nodes that successfully committed; skip unreachable nodes
+  const targetNodes = committedNodeEndpoints
+    ? nodes.filter((n) => committedNodeEndpoints.includes(n.endpoint))
+    : nodes;
   const resharedNodes: NodeNameAndEndpoint[] = [];
 
   const sendResults = await Promise.all(
-    allNodes.map(async (node) => {
+    targetNodes.map(async (node) => {
       // Find shares for this node
       const secp256k1Share = secp256k1Result.resharedShares.find(
         (s) => s.node.endpoint === node.endpoint,
@@ -281,23 +287,28 @@ export async function reshareUserKeySharesV2(
         } as const;
       }
 
-      resharedNodes.push({ name: node.name, endpoint: node.endpoint });
-
-      return reshareKeySharesV2(
+      const res = await reshareKeySharesV2(
         node.endpoint,
         idToken,
         authType,
         wallets,
         commitRevealRes.data,
       );
+
+      if (res.success) {
+        resharedNodes.push({ name: node.name, endpoint: node.endpoint });
+      }
+
+      return res;
     }),
   );
 
-  const errResults = sendResults.filter((r) => !r.success);
-  if (errResults.length > 0) {
+  const successCount = sendResults.filter((r) => r.success).length;
+  if (successCount < registrationThreshold) {
+    const errResults = sendResults.filter((r) => !r.success);
     return {
       success: false,
-      err: errResults.map((r) => (r as { err: string }).err).join("\n"),
+      err: `Reshare insufficient: ${successCount}/${targetNodes.length} nodes succeeded (need ${registrationThreshold})\n${errResults.map((r) => (r as { err: string }).err).join("\n")}`,
     };
   }
 

--- a/embed/oko_attached/src/crypto/reshare_v2.ts
+++ b/embed/oko_attached/src/crypto/reshare_v2.ts
@@ -148,7 +148,7 @@ export async function reshareUserKeySharesV2(
   secp256k1: ReshareWalletInfoSecp256k1,
   ed25519: ReshareWalletInfoEd25519,
   session: ClientCommitRevealSession,
-  committedNodeEndpoints?: string[],
+  committedNodeEndpoints: string[],
 ): Promise<Result<ReshareV2Result, string>> {
   const { threshold, nodes } = keyshareNodeMeta;
   const registrationThreshold =
@@ -237,9 +237,9 @@ export async function reshareUserKeySharesV2(
 
   // 5. Send new shares to committed nodes (partial success allowed)
   // Only send to nodes that successfully committed; skip unreachable nodes
-  const targetNodes = committedNodeEndpoints
-    ? nodes.filter((n) => committedNodeEndpoints.includes(n.endpoint))
-    : nodes;
+  const targetNodes = nodes.filter((n) =>
+    committedNodeEndpoints.includes(n.endpoint),
+  );
   const resharedNodes: NodeNameAndEndpoint[] = [];
 
   const sendResults = await Promise.all(

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/ed25519_keygen.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/ed25519_keygen.ts
@@ -16,6 +16,7 @@ import {
   createKsnCommitRevealParams,
   createOkoApiCommitRevealParams,
   type KsnCommitTarget,
+  setKsnNodePubkey,
 } from "@oko-wallet-attached/crypto/commit_reveal";
 import {
   decodeSecp256k1SharesByNode,
@@ -53,6 +54,8 @@ export async function handleExistingUserNeedsEd25519Keygen(
   authType: AuthType,
 ): Promise<Result<UserSignInResultV2, OAuthSignInError>> {
   const { threshold, nodes } = keyshareNodeMeta;
+  const registrationThreshold =
+    keyshareNodeMeta.registration_threshold ?? nodes.length;
 
   // 1. ed25519 keygen and split
   const ed25519KeygenSplitRes =
@@ -81,7 +84,7 @@ export async function handleExistingUserNeedsEd25519Keygen(
     authType,
     idToken,
     ksnCommitTargets,
-    activeNodes.length, // Only ACTIVE nodes are targets
+    registrationThreshold,
   );
   if (!commitRes.success) {
     return {
@@ -89,7 +92,24 @@ export async function handleExistingUserNeedsEd25519Keygen(
       err: { type: "sign_in_request_fail", error: commitRes.err },
     };
   }
-  const { session, readyNodes, pendingCommits } = commitRes.data;
+  let { session } = commitRes.data;
+  const { readyNodes, pendingCommits } = commitRes.data;
+
+  // 2.1. Resolve remaining pending commits so all reachable nodes
+  // get their pubkey registered in the session
+  for (const [, promise] of pendingCommits) {
+    try {
+      const result = await promise;
+      session = setKsnNodePubkey(
+        session,
+        result.nodeUrl,
+        result.nodePubkey,
+        result.operationType,
+      );
+    } catch {
+      // Node failed to commit (down) — skip
+    }
+  }
 
   // 3. Send ed25519 key shares to ks nodes using registerKeyShareEd25519V2
   const registerEd25519Results: Result<void, string>[] = await Promise.all(
@@ -131,15 +151,18 @@ export async function handleExistingUserNeedsEd25519Keygen(
       );
     }),
   );
-  const registerEd25519ErrResults = registerEd25519Results.filter(
-    (result) => result.success === false,
-  );
-  if (registerEd25519ErrResults.length > 0) {
+  const registerSuccessCount = registerEd25519Results.filter(
+    (result) => result.success === true,
+  ).length;
+  if (registerSuccessCount < registrationThreshold) {
+    const registerErrResults = registerEd25519Results.filter(
+      (result) => result.success === false,
+    );
     return {
       success: false,
       err: {
         type: "sign_in_request_fail",
-        error: registerEd25519ErrResults.map((result) => result.err).join("\n"),
+        error: registerErrResults.map((result) => result.err).join("\n"),
       },
     };
   }
@@ -282,6 +305,8 @@ export async function handleReshareAndEd25519Keygen(
   authType: AuthType,
 ): Promise<Result<UserSignInResultV2, OAuthSignInError>> {
   const { threshold, nodes } = keyshareNodeMeta;
+  const registrationThreshold =
+    keyshareNodeMeta.registration_threshold ?? nodes.length;
 
   // 1. Classify nodes
   const activeNodes = nodes.filter((n) => n.wallet_status === "ACTIVE");
@@ -312,7 +337,6 @@ export async function handleReshareAndEd25519Keygen(
   } = ed25519KeygenSplitRes.data;
 
   // 3. Commit to oko_api and ks nodes with "add_ed25519_with_reshare" operation type
-  // For add_ed25519_with_reshare, all nodes must commit since we reshare to all of them
   const ksnCommitTargets: KsnCommitTarget[] = nodes.map((node) => ({
     nodeUrl: node.endpoint,
     operationType: "add_ed25519_with_reshare" as const,
@@ -322,7 +346,7 @@ export async function handleReshareAndEd25519Keygen(
     authType,
     idToken,
     ksnCommitTargets,
-    nodes.length, // All nodes must commit for reshare
+    registrationThreshold,
   );
   if (!commitRes.success) {
     return {
@@ -330,7 +354,23 @@ export async function handleReshareAndEd25519Keygen(
       err: { type: "reshare_fail", error: commitRes.err },
     };
   }
-  const { session } = commitRes.data;
+  let { session } = commitRes.data;
+  const { pendingCommits } = commitRes.data;
+
+  // 3.1. Resolve remaining pending commits
+  for (const [, promise] of pendingCommits) {
+    try {
+      const result = await promise;
+      session = setKsnNodePubkey(
+        session,
+        result.nodeUrl,
+        result.nodePubkey,
+        result.operationType,
+      );
+    } catch {
+      // Node failed to commit (down) — skip
+    }
+  }
 
   // 4. Register ed25519 to ACTIVE nodes first
   // Must happen before keygen_ed25519 API which verifies ed25519 on user's ACTIVE secp256k1 nodes
@@ -373,10 +413,13 @@ export async function handleReshareAndEd25519Keygen(
       );
     }),
   );
-  const registerEd25519ErrResults = registerEd25519Results.filter(
-    (r) => !r.success,
-  );
-  if (registerEd25519ErrResults.length > 0) {
+  const registerEd25519SuccessCount = registerEd25519Results.filter(
+    (r) => r.success,
+  ).length;
+  if (registerEd25519SuccessCount < registrationThreshold) {
+    const registerEd25519ErrResults = registerEd25519Results.filter(
+      (r) => !r.success,
+    );
     return {
       success: false,
       err: {
@@ -498,63 +541,74 @@ export async function handleReshareAndEd25519Keygen(
     };
   }
 
-  // 8. Send shares to KSN (unified reshare API handles upsert for both wallets)
+  // 8. Send shares to committed KSN nodes (unified reshare API handles upsert)
+  const committedEndpoints = Object.keys(session.ksn_node_pubkeys);
+  const targetShares = secp256k1ExpandRes.data.reshared_user_key_shares.filter(
+    (s) => committedEndpoints.includes(s.node.endpoint),
+  );
+  const resharedNodes: Array<{ name: string; endpoint: string }> = [];
   const sendResults = await Promise.all(
-    secp256k1ExpandRes.data.reshared_user_key_shares.map(
-      async (secp256k1Share) => {
-        const ed25519Share = ed25519UserKeyShares.find(
-          (s) => s.node.endpoint === secp256k1Share.node.endpoint,
-        );
-        if (!ed25519Share) {
-          return { success: false, err: "ed25519 share not found for node" };
-        }
+    targetShares.map(async (secp256k1Share) => {
+      const ed25519Share = ed25519UserKeyShares.find(
+        (s) => s.node.endpoint === secp256k1Share.node.endpoint,
+      );
+      if (!ed25519Share) {
+        return {
+          success: false as const,
+          err: "ed25519 share not found for node",
+        };
+      }
 
-        const node = secp256k1Share.node;
+      const node = secp256k1Share.node;
 
-        // Use unified reshare API for all nodes (upsert handles ACTIVE vs new)
-        const commitRevealRes = createKsnCommitRevealParams(
-          session,
-          node.endpoint,
-          "reshare",
-        );
-        if (!commitRevealRes.success) {
-          return { success: false, err: commitRevealRes.err };
-        }
+      const commitRevealRes = createKsnCommitRevealParams(
+        session,
+        node.endpoint,
+        "reshare",
+      );
+      if (!commitRevealRes.success) {
+        return { success: false as const, err: commitRevealRes.err };
+      }
 
-        const ksnSeedShare = ed25519KsnSeedShares.find(
-          (s) => s.node.endpoint === node.endpoint,
-        );
-        if (!ksnSeedShare) {
-          return {
-            success: false,
-            err: `ed25519 seed share not found for node ${node.name}`,
-          };
-        }
-        // First: reshare with both wallets (secp256k1 verified/registered, ed25519 registered)
-        const reshareRes = await reshareKeySharesV2(
-          node.endpoint,
-          idToken,
-          authType,
-          {
-            secp256k1: {
-              public_key: secp256k1PublicKey,
-              share: encodePoint256ToKeyShareString(secp256k1Share.share),
-            },
-            ed25519: {
-              public_key: ed25519Keygen1.public_key.toHex(),
-              share: teddsaKeyShareToHex(ed25519Share.share),
-              seed_share: seedShareToHex(ksnSeedShare.share),
-            },
+      const ksnSeedShare = ed25519KsnSeedShares.find(
+        (s) => s.node.endpoint === node.endpoint,
+      );
+      if (!ksnSeedShare) {
+        return {
+          success: false as const,
+          err: `ed25519 seed share not found for node ${node.name}`,
+        };
+      }
+
+      const reshareRes = await reshareKeySharesV2(
+        node.endpoint,
+        idToken,
+        authType,
+        {
+          secp256k1: {
+            public_key: secp256k1PublicKey,
+            share: encodePoint256ToKeyShareString(secp256k1Share.share),
           },
-          commitRevealRes.data,
-        );
-        return reshareRes;
-      },
-    ),
+          ed25519: {
+            public_key: ed25519Keygen1.public_key.toHex(),
+            share: teddsaKeyShareToHex(ed25519Share.share),
+            seed_share: seedShareToHex(ksnSeedShare.share),
+          },
+        },
+        commitRevealRes.data,
+      );
+
+      if (reshareRes.success) {
+        resharedNodes.push({ name: node.name, endpoint: node.endpoint });
+      }
+
+      return reshareRes;
+    }),
   );
 
-  const errResults = sendResults.filter((r) => !r.success);
-  if (errResults.length > 0) {
+  const reshareSuccessCount = sendResults.filter((r) => r.success).length;
+  if (reshareSuccessCount < registrationThreshold) {
+    const errResults = sendResults.filter((r) => !r.success);
     return {
       success: false,
       err: {
@@ -575,9 +629,6 @@ export async function handleReshareAndEd25519Keygen(
       err: { type: "reshare_fail", error: reshareCommitRevealRes.err },
     };
   }
-  const resharedNodes = secp256k1ExpandRes.data.reshared_user_key_shares.map(
-    (s) => s.node,
-  );
   const updateRes = await makeAuthorizedOkoApiRequest<ReshareRequestV2, void>(
     "user/reshare",
     idToken,

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/ed25519_keygen.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/ed25519_keygen.ts
@@ -16,7 +16,7 @@ import {
   createKsnCommitRevealParams,
   createOkoApiCommitRevealParams,
   type KsnCommitTarget,
-  setKsnNodePubkey,
+  resolvePendingCommits,
 } from "@oko-wallet-attached/crypto/commit_reveal";
 import {
   decodeSecp256k1SharesByNode,
@@ -92,24 +92,11 @@ export async function handleExistingUserNeedsEd25519Keygen(
       err: { type: "sign_in_request_fail", error: commitRes.err },
     };
   }
-  let { session } = commitRes.data;
   const { readyNodes, pendingCommits } = commitRes.data;
-
-  // 2.1. Resolve remaining pending commits so all reachable nodes
-  // get their pubkey registered in the session
-  for (const [, promise] of pendingCommits) {
-    try {
-      const result = await promise;
-      session = setKsnNodePubkey(
-        session,
-        result.nodeUrl,
-        result.nodePubkey,
-        result.operationType,
-      );
-    } catch {
-      // Node failed to commit (down) — skip
-    }
-  }
+  const session = await resolvePendingCommits(
+    commitRes.data.session,
+    pendingCommits,
+  );
 
   // 3. Send ed25519 key shares to ks nodes using registerKeyShareEd25519V2
   const registerEd25519Results: Result<void, string>[] = await Promise.all(
@@ -354,23 +341,10 @@ export async function handleReshareAndEd25519Keygen(
       err: { type: "reshare_fail", error: commitRes.err },
     };
   }
-  let { session } = commitRes.data;
-  const { pendingCommits } = commitRes.data;
-
-  // 3.1. Resolve remaining pending commits
-  for (const [, promise] of pendingCommits) {
-    try {
-      const result = await promise;
-      session = setKsnNodePubkey(
-        session,
-        result.nodeUrl,
-        result.nodePubkey,
-        result.operationType,
-      );
-    } catch {
-      // Node failed to commit (down) — skip
-    }
-  }
+  const session = await resolvePendingCommits(
+    commitRes.data.session,
+    commitRes.data.pendingCommits,
+  );
 
   // 4. Register ed25519 to ACTIVE nodes first
   // Must happen before keygen_ed25519 API which verifies ed25519 on user's ACTIVE secp256k1 nodes

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/ed25519_keygen.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/ed25519_keygen.ts
@@ -290,6 +290,7 @@ export async function handleReshareAndEd25519Keygen(
   idToken: string,
   keyshareNodeMeta: KeyShareNodeMetaWithNodeStatusInfo,
   authType: AuthType,
+  apiKey?: string,
 ): Promise<Result<UserSignInResultV2, OAuthSignInError>> {
   const { threshold, nodes } = keyshareNodeMeta;
   const registrationThreshold =
@@ -457,6 +458,7 @@ export async function handleReshareAndEd25519Keygen(
     idToken,
     authType,
     signInCommitRevealRes.data,
+    apiKey,
   );
   if (!signInResult.success) {
     return { success: false, err: signInResult.err };

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/ed25519_keygen.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/ed25519_keygen.ts
@@ -413,10 +413,13 @@ export async function handleReshareAndEd25519Keygen(
       );
     }),
   );
+  // ed25519 register targets activeNodes only, so threshold must match
+  const ed25519RegisterThreshold =
+    keyshareNodeMeta.registration_threshold ?? activeNodes.length;
   const registerEd25519SuccessCount = registerEd25519Results.filter(
     (r) => r.success,
   ).length;
-  if (registerEd25519SuccessCount < registrationThreshold) {
+  if (registerEd25519SuccessCount < ed25519RegisterThreshold) {
     const registerEd25519ErrResults = registerEd25519Results.filter(
       (r) => !r.success,
     );

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/new_user.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/new_user.ts
@@ -15,6 +15,7 @@ import {
   createKsnCommitRevealParams,
   createOkoApiCommitRevealParams,
   type KsnCommitTarget,
+  setKsnNodePubkey,
 } from "@oko-wallet-attached/crypto/commit_reveal";
 import { encodePoint256ToKeyShareString } from "@oko-wallet-attached/crypto/key_share_utils";
 import { splitUserKeyShares } from "@oko-wallet-attached/crypto/keygen";
@@ -101,7 +102,24 @@ export async function handleNewUserV2(
       err: { type: "sign_in_request_fail", error: commitRes.err },
     };
   }
-  const { session } = commitRes.data;
+  let { session } = commitRes.data;
+  const { pendingCommits } = commitRes.data;
+
+  // 4.1. Resolve remaining pending commits so all reachable nodes
+  // get their pubkey registered in the session for downstream register
+  for (const [, promise] of pendingCommits) {
+    try {
+      const result = await promise;
+      session = setKsnNodePubkey(
+        session,
+        result.nodeUrl,
+        result.nodePubkey,
+        result.operationType,
+      );
+    } catch {
+      // Node failed to commit (down) — skip
+    }
+  }
 
   // 5. Send key shares by both curves to ks nodes using registerKeySharesV2
   const registerKeySharesResults: Result<void, string>[] = await Promise.all(

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/new_user.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/new_user.ts
@@ -81,8 +81,9 @@ export async function handleNewUserV2(
   } = ed25519KeygenSplitRes.data;
 
   // 4. Commit to oko_api and ks nodes
-  // For sign_up, all nodes must succeed since we register to all of them
   const { nodes } = keyshareNodeMeta;
+  const registrationThreshold =
+    keyshareNodeMeta.registration_threshold ?? nodes.length;
   const ksnCommitTargets: KsnCommitTarget[] = nodes.map((node) => ({
     nodeUrl: node.endpoint,
     operationType: "sign_up",
@@ -92,7 +93,7 @@ export async function handleNewUserV2(
     authType,
     idToken,
     ksnCommitTargets,
-    nodes.length, // All nodes must commit for sign_up
+    registrationThreshold,
   );
   if (!commitRes.success) {
     return {
@@ -150,10 +151,13 @@ export async function handleNewUserV2(
       );
     }),
   );
-  const registerErrResults = registerKeySharesResults.filter(
-    (result) => result.success === false,
-  );
-  if (registerErrResults.length > 0) {
+  const registerSuccessCount = registerKeySharesResults.filter(
+    (result) => result.success === true,
+  ).length;
+  if (registerSuccessCount < registrationThreshold) {
+    const registerErrResults = registerKeySharesResults.filter(
+      (result) => result.success === false,
+    );
     return {
       success: false,
       err: {

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/new_user.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/new_user.ts
@@ -15,7 +15,7 @@ import {
   createKsnCommitRevealParams,
   createOkoApiCommitRevealParams,
   type KsnCommitTarget,
-  setKsnNodePubkey,
+  resolvePendingCommits,
 } from "@oko-wallet-attached/crypto/commit_reveal";
 import { encodePoint256ToKeyShareString } from "@oko-wallet-attached/crypto/key_share_utils";
 import { splitUserKeyShares } from "@oko-wallet-attached/crypto/keygen";
@@ -102,24 +102,10 @@ export async function handleNewUserV2(
       err: { type: "sign_in_request_fail", error: commitRes.err },
     };
   }
-  let { session } = commitRes.data;
-  const { pendingCommits } = commitRes.data;
-
-  // 4.1. Resolve remaining pending commits so all reachable nodes
-  // get their pubkey registered in the session for downstream register
-  for (const [, promise] of pendingCommits) {
-    try {
-      const result = await promise;
-      session = setKsnNodePubkey(
-        session,
-        result.nodeUrl,
-        result.nodePubkey,
-        result.operationType,
-      );
-    } catch {
-      // Node failed to commit (down) — skip
-    }
-  }
+  const session = await resolvePendingCommits(
+    commitRes.data.session,
+    commitRes.data.pendingCommits,
+  );
 
   // 5. Send key shares by both curves to ks nodes using registerKeySharesV2
   const registerKeySharesResults: Result<void, string>[] = await Promise.all(

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/reshare.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/reshare.ts
@@ -24,9 +24,11 @@ export async function handleReshareV2(
   apiKey?: string,
 ): Promise<Result<UserSignInResultV2, OAuthSignInError>> {
   const { nodes } = keyshareNodeMeta;
+  const registrationThreshold =
+    keyshareNodeMeta.registration_threshold ?? nodes.length;
 
   // 1. Prepare commit targets (all nodes) with "reshare" operation type
-  // For reshare, all nodes must commit since we send reshared shares to all of them
+  // Use registration_threshold to allow partial success when some nodes are down
   const ksnCommitTargets: KsnCommitTarget[] = nodes.map((node) => ({
     nodeUrl: node.endpoint,
     operationType: "reshare" as const,
@@ -36,7 +38,7 @@ export async function handleReshareV2(
     authType,
     idToken,
     ksnCommitTargets,
-    nodes.length, // All nodes must commit for reshare
+    registrationThreshold,
   );
   if (!commitRes.success) {
     return {
@@ -115,6 +117,10 @@ export async function handleReshareV2(
   }
 
   // 4. Call reshareUserKeySharesV2 with commit-reveal session
+  // Pass committed node endpoints so reshare only targets reachable nodes
+  const committedNodeEndpoints = commitRes.data.readyNodes.map(
+    (n) => n.nodeUrl,
+  );
   const reshareRes = await reshareUserKeySharesV2(
     idToken,
     authType,
@@ -125,6 +131,7 @@ export async function handleReshareV2(
       serverVerifyingShare: serverVerifyingShareRes.data,
     },
     session,
+    committedNodeEndpoints,
   );
   if (!reshareRes.success) {
     return {

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/reshare.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/reshare.ts
@@ -8,6 +8,7 @@ import {
   commitAll,
   createOkoApiCommitRevealParams,
   type KsnCommitTarget,
+  setKsnNodePubkey,
 } from "@oko-wallet-attached/crypto/commit_reveal";
 import { reshareUserKeySharesV2 } from "@oko-wallet-attached/crypto/reshare_v2";
 import { signInV2 } from "@oko-wallet-attached/requests/oko_api";
@@ -46,7 +47,24 @@ export async function handleReshareV2(
       err: { type: "reshare_fail", error: commitRes.err },
     };
   }
-  const { session } = commitRes.data;
+  let { session } = commitRes.data;
+  const { pendingCommits } = commitRes.data;
+
+  // 2.1. Resolve remaining pending commits so all reachable nodes
+  // get their pubkey registered in the session for downstream reshare
+  for (const [, promise] of pendingCommits) {
+    try {
+      const result = await promise;
+      session = setKsnNodePubkey(
+        session,
+        result.nodeUrl,
+        result.nodePubkey,
+        result.operationType,
+      );
+    } catch {
+      // Node failed to commit (down) — skip
+    }
+  }
 
   // 3. Sign in to Oko API
   const signInCommitRevealRes = createOkoApiCommitRevealParams(
@@ -117,10 +135,8 @@ export async function handleReshareV2(
   }
 
   // 4. Call reshareUserKeySharesV2 with commit-reveal session
-  // Pass committed node endpoints so reshare only targets reachable nodes
-  const committedNodeEndpoints = commitRes.data.readyNodes.map(
-    (n) => n.nodeUrl,
-  );
+  // Use session-based endpoints (includes both readyNodes and resolved pending nodes)
+  const committedNodeEndpoints = Object.keys(session.ksn_node_pubkeys);
   const reshareRes = await reshareUserKeySharesV2(
     idToken,
     authType,

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/reshare.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/handlers/reshare.ts
@@ -8,7 +8,7 @@ import {
   commitAll,
   createOkoApiCommitRevealParams,
   type KsnCommitTarget,
-  setKsnNodePubkey,
+  resolvePendingCommits,
 } from "@oko-wallet-attached/crypto/commit_reveal";
 import { reshareUserKeySharesV2 } from "@oko-wallet-attached/crypto/reshare_v2";
 import { signInV2 } from "@oko-wallet-attached/requests/oko_api";
@@ -47,24 +47,10 @@ export async function handleReshareV2(
       err: { type: "reshare_fail", error: commitRes.err },
     };
   }
-  let { session } = commitRes.data;
-  const { pendingCommits } = commitRes.data;
-
-  // 2.1. Resolve remaining pending commits so all reachable nodes
-  // get their pubkey registered in the session for downstream reshare
-  for (const [, promise] of pendingCommits) {
-    try {
-      const result = await promise;
-      session = setKsnNodePubkey(
-        session,
-        result.nodeUrl,
-        result.nodePubkey,
-        result.operationType,
-      );
-    } catch {
-      // Node failed to commit (down) — skip
-    }
-  }
+  const session = await resolvePendingCommits(
+    commitRes.data.session,
+    commitRes.data.pendingCommits,
+  );
 
   // 3. Sign in to Oko API
   const signInCommitRevealRes = createOkoApiCommitRevealParams(

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/index.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/index.ts
@@ -461,6 +461,7 @@ export async function handleUserSignInV2(
         idToken,
         keyshareNodeMeta,
         authType,
+        apiKey,
       );
       if (!signInRes.success) {
         return {

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/user.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/user.ts
@@ -106,6 +106,7 @@ export async function handleExistingUser(
       // Update keyshare node meta to mark the lost node
       const updatedNodeMeta: KeyShareNodeMetaWithNodeStatusInfo = {
         threshold: keyshareNodeMeta.threshold,
+        registration_threshold: keyshareNodeMeta.registration_threshold,
         nodes: keyshareNodeMeta.nodes.map((n) =>
           n.name === error.affectedNode.name
             ? {


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [ ] I’ve read `CONTRIBUTING.md` and followed the guidelines.

## Summary

회원가입 시 모든 active KS Node에 register되어야 하는 all-or-nothing 방식을 개선하여, `registration_threshold` 이상 성공하면 가입을 허용하도록 수정. 일부 노드 장애 시에도 회원가입이 가능해지며, 실패한 노드는 다음 로그인 시 reshare로 커버. 
reshare 플로우도 동일하게 partial success를 허용하여 다운된 노드가 있어도 로그인이 차단되지 않도록 개선.

### Changes                                                                                               
  
- `key_share_node_meta` 테이블에 `registration_threshold` 컬럼 추가 (nullable, `>= sss_threshold` DB CHECK constraint 포함)
- `checkEmailV2` 응답에 `registration_threshold` 포함하여 클라이언트에 전달
- `checkKeyShareFromKSNodesV2`에서 부분 성공 허용 — threshold 이상 성공 시 성공한 nodeId만 반환
- `runKeygenV2` / `runKeygenEd25519`에서 성공한 node만 `wallet_ks_nodes`에 기록
- `updateWalletKSNodesForReshareV2`에서 검증된 nodeIds만 upsert
- sign-up / reshare / add_ed25519 / add_ed25519_with_reshare 클라이언트 플로우에 `registration_threshold` 기반 partial success 적용
- `commitAll` 이후 `resolvePendingCommits` 헬퍼로 모든 reachable 노드 session 등록 (5초 timeout)
- `insertKeyShareNodeMeta`에 `registration_threshold >= sss_threshold` application + DB level validation 추가
- 유닛 테스트: `checkKeyShareFromKSNodesV2` 15개, `runKeygenV2` 5개, `runKeygenEd25519` 2개
- 서버 통합 테스트: keygen e2e 4개, reshare 시나리오 4개
- `e2e_tests` 패키지 시나리오 테스트: reshare 13개, ed25519 5개, 6노드 종합 26개

### Flow Overview

**Sign-up (회원가입)**

```
commitAll(registrationThreshold) → pendingCommits resolve
→ 모든 reachable 노드에 registerKeySharesV2
→ 성공 수 >= registrationThreshold → oko_api keygen
→ 서버: checkKeyShareFromKSNodesV2(registrationThreshold) → 성공 노드만 wallet_ks_nodes 기록
```

- `registration_threshold = null` → 기존 all-or-nothing 동작 유지
- 실패한 노드는 다음 로그인 시 reshare로 자동 복구

**Reshare (로그인 시 reshare 트리거)**

```
commitAll(registrationThreshold) → pendingCommits resolve
→ activeNodes에서 기존 share 요청 → SSS expand (전체 노드용 share 생성)
→ committed 노드에만 reshare 전송 → 성공 수 >= registrationThreshold
→ oko_api: 성공 노드만 upsert (기존 wallet_ks_nodes 유지, 신규 추가)
```

- 다운 노드 있어도 threshold 충족 시 로그인 성공
- 복구된 노드는 다음 reshare에서 자연스럽게 포함

**Add Ed25519 (기존 secp256k1 유저)**

```
commitAll(registrationThreshold) → pendingCommits resolve
→ activeNodes에 ed25519 register → 성공 수 >= registrationThreshold
→ oko_api keygen_ed25519(registrationThreshold)
→ 성공 노드만 ed25519 wallet_ks_nodes 기록
```

- ed25519가 등록 안 된 노드는 다음 로그인 시 reshare로 커버

**Add Ed25519 + Reshare (기존 secp256k1 유저 + reshare 필요)**

```
commitAll(registrationThreshold) → pendingCommits resolve
→ activeNodes에 ed25519 register → 성공 수 >= registrationThreshold
→ oko_api keygen_ed25519(registrationThreshold)
→ oko_api signin
→ activeNodes에서 기존 share 요청 → SSS expand (전체 노드용 share 생성)
→ committed 노드에만 secp256k1+ed25519 reshare 전송 → 성공 수 >= registrationThreshold
→ oko_api: 성공 노드만 upsert
```

- ed25519 keygen과 secp256k1 reshare를 하나의 commit-reveal 세션에서 처리
- ed25519 register는 activeNodes 기준, reshare는 전체 committed 노드 기준

**전체 라이프사이클 (예: 6노드, registration_threshold=4)**

| Step | 상황 | 결과 |
|------|------|------|
| 1. 가입 | node 5,6 다운 | 4개 노드에 등록 |
| 2. 로그인 | node 5,6 여전히 다운 | reshare(4개) 성공, 로그인 OK |
| 3. 로그인 | node 6 복구 | reshare(5개) 성공, wallet_ks_nodes 5개로 확장 |
| 4. 로그인 | node 5,6 모두 복구 | reshare(6개) 성공, wallet_ks_nodes 6개 |
| 5. 로그인 | 전부 UP | needs_reshare=false, 일반 로그인 |    

### Manual Test

> 환경: 로컬 KS Node 6개, sss_threshold=2

#### A. Sign-up (회원가입)

##### registration_threshold = 4

- [x] **A-1** | 6개 모두 UP | 성공, wallet_ks_nodes 6개
- [x] **A-2** | 2개 DOWN (4개 alive) | 성공, wallet_ks_nodes 4개
- [x] **A-3** | 3개 DOWN (3개 alive) | 실패 (3 < threshold 4)

##### registration_threshold = null

- [x] **A-4** | 6개 모두 UP | 성공, wallet_ks_nodes 6개
- [x] **A-5** | 1개 DOWN | 실패 (5 < 6, all-or-nothing)

#### B. Sign-in (로그인, reshare 불필요)

- [x] **B-1** | A-1으로 가입 (6/6) → 6개 모두 UP | 정상 로그인, reshare 안 탐
- [x] **B-2** | A-1으로 가입 (6/6) → 2개 DOWN | 정상 로그인 (sss_threshold=2 충족), reshare 안 탐

#### C. Reshare (가입 후 reshare 트리거)

##### registration_threshold = 4

- [x] **C-1** | A-2로 가입 (4/6) → 다운 2개 여전히 DOWN | reshare 성공 (4개에 reshare), wallet_ks_nodes 4개 유지
- [x] **C-2** | A-2로 가입 (4/6) → 다운 1개 복구, 1개 여전히 DOWN | reshare 성공, wallet_ks_nodes 5개로 확장
- [x] **C-3** | A-2로 가입 (4/6) → 다운 2개 모두 복구 | reshare 성공, wallet_ks_nodes 6개로 확장
- [x] **C-4** | A-2로 가입 (4/6) → 기존 1개 추가 다운 (3개 alive) | reshare 실패 (3 < threshold 4)

##### registration_threshold = null

- [x] **C-5** | A-2로 가입 (4/6, threshold=4) → threshold를 null로 변경 → 다운 2개 여전히 DOWN | reshare 실패 (all-or-nothing, 4 < 6)
- [x] **C-6** | A-2로 가입 (4/6, threshold=4) → threshold를 null로 변경 → 6개 모두 복구 | reshare 성공

#### D. Add Ed25519 (secp256k1만 있는 기존 유저)

##### registration_threshold = 4

- [x] **D-1** | secp256k1 6/6 등록 → 6개 모두 UP | ed25519 6개 등록
- [x] **D-2** | secp256k1 6/6 등록 → 2개 DOWN | ed25519 4개 등록
- [x] **D-3** | secp256k1 6/6 등록 → 3개 DOWN | 실패 (3 < 4)
- [x] **D-4** | D-2 -> 다운 2개 모두 복구 | reshare 성공, ed25519 6개 등록

##### registration_threshold = null

- [x] **D-4** | secp256k1 6/6 등록 → 6개 모두 UP | ed25519 6개 등록
- [x] **D-5** | secp256k1 6/6 등록 → 1개 DOWN | 실패 (all-or-nothing)

#### E. Add Ed25519 + Reshare (secp256k1만 있고 reshare도 필요)

##### registration_threshold = 4

- [x] **E-1** | secp256k1 4/6 등록 → 다운 2개 여전히 DOWN | ed25519 active 4개에 등록 + reshare 4개, wallet_ks_nodes secp 4개 / ed 4개
- [x] **E-2** | secp256k1 4/6 등록 → 다운 2개 모두 복구 | ed25519 active 4개에 등록 + reshare 6개, wallet_ks_nodes 6개로 확장
- [x] **E-3** | secp256k1 4/6 등록 → 다운 2개 + 기존 1개 추가 DOWN (3개 alive) | 실패 (3 < 4)

##### registration_threshold = null

- [x] **E-4** | secp256k1 5/5 등록, 새 노드 추가 → 6개 모두 UP | 성공, 전체 등록
- [x] **E-5** | secp256k1 5/5 등록, 새 노드 추가 → 새 노드 DOWN | 실패 (all-or-nothing)

#### F. 전체 라이프사이클 (registration_threshold = 4)

- [x] **F-1** | 회원가입 | node 5,6 DOWN | 성공, secp256k1+ed25519 4개 노드 등록
- [x] **F-2** | 로그아웃 → 로그인 | node 5,6 여전히 DOWN | needs_reshare=true → reshare 4개에 성공 → 로그인 성공
- [x] **F-3** | 로그아웃 → 로그인 | node 6 복구, node 5 여전히 DOWN | needs_reshare=true → reshare 5개에 성공 → wallet_ks_nodes 5개
- [x] **F-4** | 로그아웃 → 로그인 | node 5,6 모두 복구 | needs_reshare=true → reshare 6개에 성공 → wallet_ks_nodes 6개
- [x] **F-5** | 로그아웃 → 로그인 | 6개 모두 UP | needs_reshare=false → 일반 로그인 (reshare 안 탐)                                                                                       

## Links (Issue References, etc, if there's any)

OKO-773
