### PR TITLE
demo_web: fix theme sync between demo and sign modal

### DIFF
--- a/apps/demo_web/src/hooks/use_theme_sync.ts
+++ b/apps/demo_web/src/hooks/use_theme_sync.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect } from "react";
+import { useEffect } from "react";
 
 import { useThemeState } from "@oko-wallet-demo-web/state/theme";
 
@@ -6,8 +6,14 @@ export const useThemeSync = () => {
   const { initialize, setTheme } = useThemeState();
   const preference = useThemeState((s) => s.preference);
 
-  useLayoutEffect(() => {
-    initialize();
+  useEffect(() => {
+    if (useThemeState.persist.hasHydrated()) {
+      initialize();
+      return;
+    }
+    return useThemeState.persist.onFinishHydration(() => {
+      initialize();
+    });
   }, [initialize]);
 
   useEffect(() => {

--- a/apps/demo_web/src/hooks/use_theme_sync_to_iframe.ts
+++ b/apps/demo_web/src/hooks/use_theme_sync_to_iframe.ts
@@ -1,64 +1,41 @@
 import { useEffect } from "react";
 
+import { useSDKState } from "@oko-wallet-demo-web/state/sdk";
 import { useThemeState } from "@oko-wallet-demo-web/state/theme";
 
 const OKO_IFRAME_ID = "oko-attached";
 
 /**
- * Sends the current resolved theme to the attached iframe via postMessage
- * whenever it changes. This keeps the Sign Modal's theme in sync with
- * the Demo web's theme toggle.
+ * Sends the current resolved theme to the attached iframe via postMessage.
  *
- * Also sends on iframe load to cover the initial page load case
- * (new tab with persisted theme that differs from the backend default).
+ * Waits until the SDK is fully initialized (iframe init ack received)
+ * before sending, which guarantees the iframe's message handler is
+ * registered. Re-sends whenever the theme changes (user toggle).
  */
 export const useThemeSyncToIframe = () => {
   const theme = useThemeState((s) => s.theme);
+  const isIframeReady = useSDKState((s) => s.isCosmosLazyInitialized);
 
   useEffect(() => {
-    const sendTheme = (target: HTMLIFrameElement) => {
-      target.contentWindow?.postMessage(
-        {
-          target: "oko_attached",
-          msg_type: "set_theme",
-          payload: { theme },
-        },
-        "*",
-      );
-    };
-
-    const attach = (iframe: HTMLIFrameElement) => {
-      if (iframe.contentWindow) {
-        sendTheme(iframe);
-      }
-      const onLoad = () => sendTheme(iframe);
-      iframe.addEventListener("load", onLoad);
-      return () => iframe.removeEventListener("load", onLoad);
-    };
+    if (!isIframeReady) {
+      return;
+    }
 
     const iframe = document.getElementById(
       OKO_IFRAME_ID,
     ) as HTMLIFrameElement | null;
 
-    if (iframe) {
-      return attach(iframe);
+    if (!iframe?.contentWindow) {
+      return;
     }
 
-    // iframe not yet in DOM — watch for SDK to create it
-    let detach: (() => void) | undefined;
-    const observer = new MutationObserver(() => {
-      const el = document.getElementById(
-        OKO_IFRAME_ID,
-      ) as HTMLIFrameElement | null;
-      if (el) {
-        observer.disconnect();
-        detach = attach(el);
-      }
-    });
-    observer.observe(document.body, { childList: true, subtree: true });
-    return () => {
-      observer.disconnect();
-      detach?.();
-    };
-  }, [theme]);
+    iframe.contentWindow.postMessage(
+      {
+        target: "oko_attached",
+        msg_type: "set_theme",
+        payload: { theme },
+      },
+      "*",
+    );
+  }, [theme, isIframeReady]);
 };

--- a/embed/oko_attached/src/window_msgs/index.ts
+++ b/embed/oko_attached/src/window_msgs/index.ts
@@ -84,6 +84,10 @@ export function makeMsgHandler() {
       if (theme === "light" || theme === "dark") {
         setColorScheme(theme);
         useMemoryState.getState().setResolvedTheme(theme);
+        const hostOrigin = useMemoryState.getState().hostOrigin;
+        if (hostOrigin) {
+          useAppState.getState().setTheme(hostOrigin, theme);
+        }
         console.debug("[attached] set_theme applied:", theme);
       }
       return;


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [ ] I’ve read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Demo Web에서 페이지 리로드 시 Sign Modal의 테마가 올바르게 적용되지 않던 문제 수정
  - iframe 테마 동기화 로직 간소화 — MutationObserver/load 이벤트 기반에서 SDK 초기화 완료(`isCosmosLazyInitialized`) 대기 후 postMessage
  전송으로 변경
  - Attached iframe에서 `set_theme` 수신 시 `appState`에도 테마 저장 — 로고 등 appState 기반 테마 참조가 동기화되지 않던 문제 수정

## Links (Issue References, etc, if there's any)

<!-- List related issues or PRs (e.g., Closes #123; Related #456). -->
