### PR TITLE
oko_attached: force light theme on export key display view

### DIFF
--- a/embed/oko_attached/src/components/export/export_display.module.scss
+++ b/embed/oko_attached/src/components/export/export_display.module.scss
@@ -1,13 +1,3 @@
-:global(:root) {
-  --bg-secondary: #fafafa;
-  --bg-secondary-hover: #f5f5f5;
-  --bg-brand-solid: #181d27;
-  --bg-brand-solid-hover: #333843;
-  --text-primary: #181d27;
-  --text-secondary: #414651;
-  --fg-primary: #181d27;
-}
-
 :global(html) {
   margin: 0;
   padding: 0;
@@ -97,11 +87,6 @@
 .copyButtonIcon {
   display: flex;
   align-items: center;
-  color: var(--brand-300, #a4a7ae);
-}
-
-.copyButton:hover .copyButtonIcon {
-  color: #d5d7da;
 }
 
 .spacer16 {

--- a/embed/oko_attached/src/components/export/export_display.module.scss
+++ b/embed/oko_attached/src/components/export/export_display.module.scss
@@ -1,6 +1,8 @@
 :global(:root) {
   --bg-secondary: #fafafa;
   --bg-secondary-hover: #f5f5f5;
+  --bg-brand-solid: #181d27;
+  --bg-brand-solid-hover: #333843;
   --text-primary: #181d27;
   --text-secondary: #414651;
   --fg-primary: #181d27;

--- a/embed/oko_attached/src/components/export/export_display.tsx
+++ b/embed/oko_attached/src/components/export/export_display.tsx
@@ -76,6 +76,20 @@ const VALID_KEY_TYPES: ReadonlySet<string> = new Set(["secp256k1", "ed25519"]);
 const MAX_KEY_REQUEST_ATTEMPTS = 3;
 
 export const ExportDisplay: FC = () => {
+  // Force light theme — this route is only used inside user_dashboard which has no dark mode
+  useEffect(() => {
+    const root = document.documentElement;
+    const prevTheme = root.getAttribute("data-theme");
+    root.setAttribute("data-theme", "light");
+    return () => {
+      if (prevTheme) {
+        root.setAttribute("data-theme", prevTheme);
+      } else {
+        root.removeAttribute("data-theme");
+      }
+    };
+  }, []);
+
   const keyType = useMemo(() => {
     const raw = new URLSearchParams(window.location.search).get("key_type");
     const parsed = raw && VALID_KEY_TYPES.has(raw) ? (raw as CurveType) : null;


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [ ] I’ve read `CONTRIBUTING.md` and followed the guidelines.

## Summary
유저 대시보드는 아직 다크모드 지원을 하지 않기에 export private key 뷰가 light mode가 되도록수정
<!-- What changed, why it changed, and the impact on users/system. -->

## Links (Issue References, etc, if there's any)

<!-- List related issues or PRs (e.g., Closes #123; Related #456). -->
