### PR TITLE
oko_api: use timing-safe comparison for KS node telemetry password

### DIFF
--- a/backend/oko_api/server/src/routes/tss_v1/ks_node_telemetry.ts
+++ b/backend/oko_api/server/src/routes/tss_v1/ks_node_telemetry.ts
@@ -5,6 +5,7 @@ import {
 } from "@oko-wallet/oko-api-openapi/tss";
 import type { OkoApiResponse } from "@oko-wallet/oko-types/api_response";
 import type { KSNodeTelemetryRequest } from "@oko-wallet/oko-types/tss";
+import { timingSafeEqual } from "crypto";
 import type { Response, Router } from "express";
 import { z } from "zod";
 
@@ -66,7 +67,12 @@ export function setKSNodeTelemetryRoutes(router: Router) {
       }
 
       const expectedPassword = req.app.locals.ks_node_report_password;
-      if (password !== expectedPassword) {
+      const passwordBuf = Buffer.from(password, "utf-8");
+      const expectedBuf = Buffer.from(expectedPassword, "utf-8");
+      if (
+        passwordBuf.length !== expectedBuf.length ||
+        !timingSafeEqual(passwordBuf, expectedBuf)
+      ) {
         res.status(401).json({
           success: false,
           code: "UNAUTHORIZED",


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [ ] I’ve read `CONTRIBUTING.md` and followed the guidelines.

## Summary

기존 !== 비교는 문자열을 앞에서부터 순차적으로 비교하기 때문에, 일치하는 문자 수에 따라 응답 시간이 달라집니다. 공격자가 이 시간 차이를 반복 측정하면 한 글자씩 패스워드를 유추할 수 있습니다 (타이밍 공격). timingSafeEqual은 입력값에 관계없이 항상 동일한 시간이 소요되어 이 공격을 차단합니다.

<!-- What changed, why it changed, and the impact on users/system. -->

## Links (Issue References, etc, if there's any)

<!-- List related issues or PRs (e.g., Closes #123; Related #456). -->
