### PR TITLE
OKO-816

### DIFF
--- a/backend/oko_api/server/src/api/tss/keplr_auth/index.ts
+++ b/backend/oko_api/server/src/api/tss/keplr_auth/index.ts
@@ -19,6 +19,7 @@ export const USER_ISSUER = "https://api.oko.app";
 export const USER_AUDIENCE = "https://api.oko.app";
 
 const EXPIRATION_WINDOW = 1 * 24 * 60 * 60 * 1000; // 1 day in ms
+const SILENT_SIGNIN_MAX_TOKEN_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days in ms
 
 export function generateUserToken(
   args: GenerateUserTokenArgs,
@@ -118,7 +119,19 @@ export function verifyUserToken(
 
     const now = dayjs();
     const issuedAt = dayjs(new Date(payload.iat * 1000));
-    const isOrWillSoonBeExpired = now.diff(issuedAt) > EXPIRATION_WINDOW * 0.75;
+    const tokenAgeMs = now.diff(issuedAt);
+
+    if (tokenAgeMs > SILENT_SIGNIN_MAX_TOKEN_AGE) {
+      return {
+        success: false,
+        err: {
+          type: "expired_beyond_renewal",
+          msg: "Token is too old for silent renewal. Please re-authenticate.",
+        },
+      };
+    }
+
+    const isOrWillSoonBeExpired = tokenAgeMs > EXPIRATION_WINDOW * 0.75;
 
     if (isOrWillSoonBeExpired) {
       return {
@@ -176,7 +189,19 @@ export function verifyUserTokenV2(
 
     const now = dayjs();
     const issuedAt = dayjs(new Date(payload.iat * 1000));
-    const isOrWillSoonBeExpired = now.diff(issuedAt) > EXPIRATION_WINDOW * 0.75;
+    const tokenAgeMs = now.diff(issuedAt);
+
+    if (tokenAgeMs > SILENT_SIGNIN_MAX_TOKEN_AGE) {
+      return {
+        success: false,
+        err: {
+          type: "expired_beyond_renewal",
+          msg: "Token is too old for silent renewal. Please re-authenticate.",
+        },
+      };
+    }
+
+    const isOrWillSoonBeExpired = tokenAgeMs > EXPIRATION_WINDOW * 0.75;
 
     if (isOrWillSoonBeExpired) {
       return {

--- a/backend/oko_api/server/src/api/tss/keplr_auth/types.ts
+++ b/backend/oko_api/server/src/api/tss/keplr_auth/types.ts
@@ -13,6 +13,7 @@ export type VerifyUserTokenResult =
       type: "expired";
       payload: UserTokenJWTPayload | UserTokenJWTPayloadV2;
     }
+  | { type: "expired_beyond_renewal"; msg: string }
   | {
       type: "unknown_error";
       msg: string;

--- a/backend/oko_api/server/src/routes/tss_v1/user.ts
+++ b/backend/oko_api/server/src/routes/tss_v1/user.ts
@@ -344,6 +344,13 @@ export function setUserV1Routes(router: Router) {
             data: { token: signInRes.data.token },
           });
           return;
+        } else if (err.type === "expired_beyond_renewal") {
+          res.status(401).json({
+            success: false,
+            code: "INVALID_AUTH_TOKEN",
+            msg: err.msg,
+          });
+          return;
         } else {
           res.status(401).json({
             success: false,

--- a/backend/oko_api/server/src/routes/tss_v2/user_signin_silently.ts
+++ b/backend/oko_api/server/src/routes/tss_v2/user_signin_silently.ts
@@ -166,6 +166,15 @@ export async function userSignInSilentlyV2(
     return;
   }
 
+  if (v2Result.err.type === "expired_beyond_renewal") {
+    res.status(401).json({
+      success: false,
+      code: "INVALID_AUTH_TOKEN",
+      msg: v2Result.err.msg,
+    });
+    return;
+  }
+
   res.status(401).json({
     success: false,
     code: "INVALID_REQUEST",

--- a/backend/user_dashboard_api/src/auth/index.ts
+++ b/backend/user_dashboard_api/src/auth/index.ts
@@ -16,6 +16,7 @@ import jwt from "jsonwebtoken";
 import {
   CUSTOMER_AUDIENCE,
   CUSTOMER_ISSUER,
+  SILENT_SIGNIN_MAX_TOKEN_AGE,
   USER_AUDIENCE,
   USER_ISSUER,
   USER_TOKEN_EXPIRATION_WINDOW,
@@ -26,6 +27,7 @@ export type UserTokenJWTPayloadV2 = UserTokenPayloadV2 & jwt.JwtPayload;
 export type VerifyUserTokenResult =
   | { type: "invalid_token"; msg: string }
   | { type: "expired"; payload: UserTokenJWTPayload | UserTokenJWTPayloadV2 }
+  | { type: "expired_beyond_renewal"; msg: string }
   | { type: "unknown_error"; msg: string };
 export interface VerifyUserTokenArgs {
   token: string;
@@ -56,8 +58,20 @@ export function verifyUserToken(
 
     const now = dayjs();
     const issuedAt = dayjs(new Date(payload.iat * 1000));
+    const tokenAgeMs = now.diff(issuedAt);
+
+    if (tokenAgeMs > SILENT_SIGNIN_MAX_TOKEN_AGE) {
+      return {
+        success: false,
+        err: {
+          type: "expired_beyond_renewal",
+          msg: "Token is too old for silent renewal. Please re-authenticate.",
+        },
+      };
+    }
+
     const isOrWillSoonBeExpired =
-      now.diff(issuedAt) > USER_TOKEN_EXPIRATION_WINDOW * 0.75;
+      tokenAgeMs > USER_TOKEN_EXPIRATION_WINDOW * 0.75;
 
     if (isOrWillSoonBeExpired) {
       return {
@@ -115,8 +129,20 @@ export function verifyUserTokenV2(
 
     const now = dayjs();
     const issuedAt = dayjs(new Date(payload.iat * 1000));
+    const tokenAgeMs = now.diff(issuedAt);
+
+    if (tokenAgeMs > SILENT_SIGNIN_MAX_TOKEN_AGE) {
+      return {
+        success: false,
+        err: {
+          type: "expired_beyond_renewal",
+          msg: "Token is too old for silent renewal. Please re-authenticate.",
+        },
+      };
+    }
+
     const isOrWillSoonBeExpired =
-      now.diff(issuedAt) > USER_TOKEN_EXPIRATION_WINDOW * 0.75;
+      tokenAgeMs > USER_TOKEN_EXPIRATION_WINDOW * 0.75;
 
     if (isOrWillSoonBeExpired) {
       return {

--- a/backend/user_dashboard_api/src/constants/index.ts
+++ b/backend/user_dashboard_api/src/constants/index.ts
@@ -12,3 +12,4 @@ export const CUSTOMER_AUDIENCE = "https://api.oko.app";
 export const USER_ISSUER = "https://api.oko.app";
 export const USER_AUDIENCE = "https://api.oko.app";
 export const USER_TOKEN_EXPIRATION_WINDOW = 1 * 24 * 60 * 60 * 1000; // 1 day in ms
+export const SILENT_SIGNIN_MAX_TOKEN_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days in ms

--- a/embed/oko_attached/src/components/attached_initialized/use_initialize_app.ts
+++ b/embed/oko_attached/src/components/attached_initialized/use_initialize_app.ts
@@ -35,8 +35,7 @@ export function useInitializeApp() {
     getAuthToken,
     getWallet,
     setAuthToken,
-    setWallet,
-    setWalletEd25519,
+    resetAll,
     setTheme,
     getTheme,
   } = useAppState();
@@ -148,8 +147,7 @@ export function useInitializeApp() {
         );
 
         if (wasInvalidated) {
-          setWallet(hostOrigin, null);
-          setWalletEd25519(hostOrigin, null);
+          resetAll(hostOrigin);
         }
 
         const rawTheme = searchParams.get("theme");

--- a/embed/oko_attached/src/components/attached_initialized/use_initialize_app.ts
+++ b/embed/oko_attached/src/components/attached_initialized/use_initialize_app.ts
@@ -257,6 +257,25 @@ function sendInitMsg(hostOrigin: string, msg: OkoWalletMsgInit) {
   return sendMsgToWindow(window.parent, msg, hostOrigin);
 }
 
+function isTokenExpired(token: string): boolean {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) {
+      return true;
+    }
+    const decoded = JSON.parse(
+      atob(payload.replace(/-/g, "+").replace(/_/g, "/")),
+    );
+    const exp = Number(decoded.exp);
+    if (!Number.isFinite(exp)) {
+      return true;
+    }
+    return Math.floor(Date.now() / 1000) >= exp;
+  } catch {
+    return true;
+  }
+}
+
 async function silentlyRefreshAuthToken(
   authToken: string | null,
   hostOrigin: string,
@@ -287,6 +306,15 @@ async function silentlyRefreshAuthToken(
       return true;
     }
 
+    // Non-401 failure (network error, server error, etc.): check if
+    // the token has expired client-side. If so, clear state so the
+    // host app can prompt re-auth rather than failing on subsequent
+    // signing requests with a stale token.
+    if (isTokenExpired(authToken)) {
+      setAuthToken(hostOrigin, null);
+      return true;
+    }
+
     return false;
   }
 
@@ -297,6 +325,15 @@ async function silentlyRefreshAuthToken(
 
       setAuthToken(hostOrigin, resp.data.token);
     }
+    return false;
+  }
+
+  // Server returned 200 but application-level failure (e.g. UNKNOWN_ERROR).
+  // Token renewal did not succeed — check if the token has expired.
+  console.error("[attached] silent sign-in app error, code: %s", resp.code);
+  if (isTokenExpired(authToken)) {
+    setAuthToken(hostOrigin, null);
+    return true;
   }
 
   return false;

--- a/embed/oko_attached/src/components/attached_initialized/use_initialize_app.ts
+++ b/embed/oko_attached/src/components/attached_initialized/use_initialize_app.ts
@@ -31,8 +31,15 @@ import type { MsgEventContext } from "@oko-wallet-attached/window_msgs/types";
 
 export function useInitializeApp() {
   const { setHostOrigin, setReferralInfo } = useMemoryState();
-  const { getAuthToken, getWallet, setAuthToken, setTheme, getTheme } =
-    useAppState();
+  const {
+    getAuthToken,
+    getWallet,
+    setAuthToken,
+    setWallet,
+    setWalletEd25519,
+    setTheme,
+    getTheme,
+  } = useAppState();
   const [isHydrated, setIsHydrated] = useState(false);
   const [resolvedTheme, setResolvedTheme] = useState<Theme | null>(null);
 
@@ -133,12 +140,17 @@ export function useInitializeApp() {
 
         const authToken = getAuthToken(hostOrigin);
         const walletForAuth = getWallet(hostOrigin);
-        await silentlyRefreshAuthToken(
+        const wasInvalidated = await silentlyRefreshAuthToken(
           authToken,
           hostOrigin,
           setAuthToken,
           walletForAuth?.authType,
         );
+
+        if (wasInvalidated) {
+          setWallet(hostOrigin, null);
+          setWalletEd25519(hostOrigin, null);
+        }
 
         const rawTheme = searchParams.get("theme");
         const sdkThemeParam: OkoWalletTheme | null =
@@ -252,29 +264,42 @@ async function silentlyRefreshAuthToken(
   hostOrigin: string,
   setAuthToken: (hostOrigin: string, token: string | null) => void,
   authType?: AuthType,
-) {
-  if (authToken) {
-    const res = await makeAuthorizedOkoApiRequest<any, SignInSilentlyResponse>(
-      "user/signin_silently",
-      authToken,
-      {
-        auth_type: authType,
-      },
-      TSS_V2_ENDPOINT,
-    );
+): Promise<boolean> {
+  if (!authToken) {
+    return false;
+  }
 
-    if (!res.success) {
-      console.error("Error logging in, err: %s", res.err);
-      return;
+  const res = await makeAuthorizedOkoApiRequest<any, SignInSilentlyResponse>(
+    "user/signin_silently",
+    authToken,
+    {
+      auth_type: authType,
+    },
+    TSS_V2_ENDPOINT,
+  );
+
+  if (!res.success) {
+    console.error("Error logging in, err: %s", res.err);
+
+    // Token rejected (e.g. expired beyond renewal window) — clear it
+    // so the init message reports unauthenticated state and the host
+    // app can prompt re-authentication.
+    if (res.err.type === "status_fail" && res.err.status === 401) {
+      setAuthToken(hostOrigin, null);
+      return true;
     }
 
-    const resp = res.data;
-    if (resp.success) {
-      if (resp.data.token !== null) {
-        console.log("[attached] refreshing auth token");
+    return false;
+  }
 
-        setAuthToken(hostOrigin, resp.data.token);
-      }
+  const resp = res.data;
+  if (resp.success) {
+    if (resp.data.token !== null) {
+      console.log("[attached] refreshing auth token");
+
+      setAuthToken(hostOrigin, resp.data.token);
     }
   }
+
+  return false;
 }

--- a/embed/oko_attached/src/components/attached_initialized/use_initialize_app.ts
+++ b/embed/oko_attached/src/components/attached_initialized/use_initialize_app.ts
@@ -257,25 +257,6 @@ function sendInitMsg(hostOrigin: string, msg: OkoWalletMsgInit) {
   return sendMsgToWindow(window.parent, msg, hostOrigin);
 }
 
-function isTokenExpired(token: string): boolean {
-  try {
-    const payload = token.split(".")[1];
-    if (!payload) {
-      return true;
-    }
-    const decoded = JSON.parse(
-      atob(payload.replace(/-/g, "+").replace(/_/g, "/")),
-    );
-    const exp = Number(decoded.exp);
-    if (!Number.isFinite(exp)) {
-      return true;
-    }
-    return Math.floor(Date.now() / 1000) >= exp;
-  } catch {
-    return true;
-  }
-}
-
 async function silentlyRefreshAuthToken(
   authToken: string | null,
   hostOrigin: string,
@@ -306,15 +287,9 @@ async function silentlyRefreshAuthToken(
       return true;
     }
 
-    // Non-401 failure (network error, server error, etc.): check if
-    // the token has expired client-side. If so, clear state so the
-    // host app can prompt re-auth rather than failing on subsequent
-    // signing requests with a stale token.
-    if (isTokenExpired(authToken)) {
-      setAuthToken(hostOrigin, null);
-      return true;
-    }
-
+    // Non-401 failures (network error, server error, etc.): keep the
+    // token. The server may still accept it for renewal on the next
+    // attempt (tokens past exp can be renewed within the 7-day window).
     return false;
   }
 
@@ -329,12 +304,7 @@ async function silentlyRefreshAuthToken(
   }
 
   // Server returned 200 but application-level failure (e.g. UNKNOWN_ERROR).
-  // Token renewal did not succeed — check if the token has expired.
+  // Keep the token — the server may still renew it on the next attempt.
   console.error("[attached] silent sign-in app error, code: %s", resp.code);
-  if (isTokenExpired(authToken)) {
-    setAuthToken(hostOrigin, null);
-    return true;
-  }
-
   return false;
 }


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [ ] I’ve read `CONTRIBUTING.md` and followed the guidelines.

## Summary
Silent Sign-In (`/tss/v1/user/signin_silently`, `/tss/v2/user/signin_silently`) 엔드포인트에서 만료된 JWT의 갱신 가능 기간에 상한선이 없어, 서명만 유효하면 아무리 오래된 토큰이라도 무한히 새 토큰을 발급받을 수 있음
<!-- What changed, why it changed, and the impact on users/system. -->

- `verifyUserToken()` / `verifyUserTokenV2()`에 `SILENT_SIGNIN_MAX_TOKEN_AGE` (7일) 검사를 추가하여, 7일 초과된 토큰은 갱신을 거부하고 OAuth 재인증을 강제합니다.
- `VerifyUserTokenResult` 타입에 `expired_beyond_renewal` variant를 추가하여, 갱신 불가능한 만료 토큰의 payload가 호출자에게 노출되지 않도록 합니다.
- V1/V2 Silent Sign-In 핸들러에서 새 타입을 401로 처리합니다.
- `user_dashboard_api`의 동일한 verify 함수도 일관성을 위해 동기화했습니다.

### 사용자 영향
- 7일 이내 재방문 사용자: 변화 없음
- 7일 초과 미접속 사용자: 다음 접속 시 OAuth 재인증 1회 필요 (지갑/키 데이터 영향 없음)
- 디앱 통합: 클라이언트/SDK 코드 변경 불필요 (기존 에러 핸들링으로 자연스럽게 처리됨)
