### PR TITLE
customer_dashboard: increase password max length to 20 and extend email verification timer

### DIFF
--- a/apps/customer_dashboard/src/app/users/forgot_password/page.tsx
+++ b/apps/customer_dashboard/src/app/users/forgot_password/page.tsx
@@ -369,11 +369,11 @@ export default function ForgotPasswordPage() {
             }}
             fullWidth
             requiredSymbol
-            maxLength={16}
+            maxLength={PASSWORD_MAX_LENGTH}
             helpText={
               error
                 ? undefined
-                : "Password must be 8-16 characters and must include numbers."
+                : "Password must be 8-20 characters and must include numbers."
             }
             SideComponent={
               <button
@@ -397,7 +397,7 @@ export default function ForgotPasswordPage() {
             }}
             fullWidth
             requiredSymbol
-            maxLength={16}
+            maxLength={PASSWORD_MAX_LENGTH}
             SideComponent={
               <button
                 type="button"

--- a/apps/customer_dashboard/src/components/reset_password/reset_password.tsx
+++ b/apps/customer_dashboard/src/components/reset_password/reset_password.tsx
@@ -9,6 +9,7 @@ import { type FC, useState } from "react";
 
 import styles from "./reset_password.module.scss";
 import { useResetPasswordForm } from "./use_reset_password_form";
+import { PASSWORD_MAX_LENGTH } from "@oko-wallet-ct-dashboard/constants";
 import { AccountForm } from "@oko-wallet-ct-dashboard/ui";
 
 interface ResetPasswordProps {
@@ -65,11 +66,11 @@ export const ResetPassword: FC<ResetPasswordProps> = ({ isAfterLogin }) => {
           placeholder="Enter new password"
           requiredSymbol
           type={showNewPassword ? "text" : "password"}
-          maxLength={16}
+          maxLength={PASSWORD_MAX_LENGTH}
           helpText={
             errors.newPassword
               ? ""
-              : "Password must be 8–16 characters and must include numbers."
+              : "Password must be 8–20 characters and must include numbers."
           }
           error={errors.newPassword?.message}
           fullWidth
@@ -92,7 +93,7 @@ export const ResetPassword: FC<ResetPasswordProps> = ({ isAfterLogin }) => {
           placeholder="Confirm password"
           requiredSymbol
           type={showConfirmPassword ? "text" : "password"}
-          maxLength={16}
+          maxLength={PASSWORD_MAX_LENGTH}
           error={errors.confirmPassword?.message}
           fullWidth
           SideComponent={

--- a/apps/customer_dashboard/src/constants/index.ts
+++ b/apps/customer_dashboard/src/constants/index.ts
@@ -1,10 +1,10 @@
 export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 export const PASSWORD_MIN_LENGTH = 8;
-export const PASSWORD_MAX_LENGTH = 16;
+export const PASSWORD_MAX_LENGTH = 20;
 export const PASSWORD_CONTAINS_NUMBER_REGEX = /\d/;
 
 export const SIX_DIGITS_REGEX = /^\d{6}$/;
 
-export const EMAIL_VERIFICATION_TIMER_SECONDS = 59;
+export const EMAIL_VERIFICATION_TIMER_SECONDS = 180;
 
 export const GET_STARTED_URL = "https://form.typeform.com/to/MxrBGq9b";

--- a/backend/admin_api/src/utils/password.test.ts
+++ b/backend/admin_api/src/utils/password.test.ts
@@ -1,0 +1,17 @@
+import { generatePassword } from "./password";
+
+describe("generatePassword", () => {
+  it("returns a 20-character password by default", () => {
+    const password = generatePassword();
+
+    expect(password).toHaveLength(20);
+  });
+
+  it("always includes lowercase, uppercase, and numeric characters", () => {
+    const password = generatePassword();
+
+    expect(password).toMatch(/[a-z]/);
+    expect(password).toMatch(/[A-Z]/);
+    expect(password).toMatch(/\d/);
+  });
+});

--- a/backend/admin_api/src/utils/password.ts
+++ b/backend/admin_api/src/utils/password.ts
@@ -11,7 +11,7 @@ function getRandomChar(charset: string): string {
   }
 }
 
-export function generatePassword(length: number = 16): string {
+export function generatePassword(length: number = 20): string {
   const lower = "abcdefghijklmnopqrstuvwxyz";
   const upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
   const numbers = "0123456789";

--- a/backend/ct_dashboard_api/src/constants/index.ts
+++ b/backend/ct_dashboard_api/src/constants/index.ts
@@ -1,7 +1,7 @@
 export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 export const PASSWORD_MIN_LENGTH = 4;
 export const CHANGED_PASSWORD_MIN_LENGTH = 8;
-export const CHANGED_PASSWORD_MAX_LENGTH = 16;
+export const CHANGED_PASSWORD_MAX_LENGTH = 20;
 export const PASSWORD_CONTAINS_NUMBER_REGEX = /\d/;
 
 export const SIX_DIGITS_REGEX = /^\d{6}$/;

--- a/backend/ct_dashboard_api/src/routes/v1/change_password.ts
+++ b/backend/ct_dashboard_api/src/routes/v1/change_password.ts
@@ -118,7 +118,7 @@ export async function changePassword(
       res.status(400).json({
         success: false,
         code: "INVALID_EMAIL_OR_PASSWORD",
-        msg: "Password must be at most 16 characters long",
+        msg: `Password must be at most ${CHANGED_PASSWORD_MAX_LENGTH} characters long`,
       });
       return;
     }

--- a/backend/ct_dashboard_api/src/routes/v1/reset_password_confirm.ts
+++ b/backend/ct_dashboard_api/src/routes/v1/reset_password_confirm.ts
@@ -102,7 +102,7 @@ export async function resetPasswordConfirm(
       res.status(400).json({
         success: false,
         code: "INVALID_EMAIL_OR_PASSWORD",
-        msg: "Password too long",
+        msg: `Password must be at most ${CHANGED_PASSWORD_MAX_LENGTH} characters long`,
       });
       return;
     }

--- a/backend/ct_dashboard_api/src/routes/v1/reset_password_confirm.ts
+++ b/backend/ct_dashboard_api/src/routes/v1/reset_password_confirm.ts
@@ -93,7 +93,7 @@ export async function resetPasswordConfirm(
       res.status(400).json({
         success: false,
         code: "INVALID_EMAIL_OR_PASSWORD",
-        msg: "Password too short",
+        msg: `Password must be at least ${CHANGED_PASSWORD_MIN_LENGTH} characters long`,
       });
       return;
     }

--- a/backend/openapi/src/ct_dashboard/customer_auth.ts
+++ b/backend/openapi/src/ct_dashboard/customer_auth.ts
@@ -115,11 +115,11 @@ export const ChangePasswordRequestSchema = registry.register(
     new_password: z
       .string()
       .min(8)
-      .max(16)
+      .max(20)
       .regex(/\d/, "Password must include at least one number")
       .openapi({
         description:
-          "New password to set (8-16 characters, must include at least one number)",
+          "New password to set (8-20 characters, must include at least one number)",
       }),
     original_password: z.string().optional().openapi({
       description: "Current password for verification",
@@ -220,11 +220,11 @@ export const ResetPasswordConfirmRequestSchema = registry.register(
     newPassword: z
       .string()
       .min(8)
-      .max(16)
+      .max(20)
       .regex(/\d/, "Password must include at least one number")
       .openapi({
         description:
-          "The new password (8-16 characters, must include at least one number)",
+          "The new password (8-20 characters, must include at least one number)",
       }),
   }),
 );


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

### Password Max Length 16 → 20
- Increased the password maximum length from 16 to 20 characters across all enforcement layers:
  - **Backend constants**: `CHANGED_PASSWORD_MAX_LENGTH = 20` in `ct_dashboard_api`
  - **OpenAPI schemas**: `.max(20)` and updated descriptions for `ChangePasswordRequestSchema` and `ResetPasswordConfirmRequestSchema`
  - **Route validation**: Replaced hardcoded error messages with template strings using the constant in `change_password.ts` and `reset_password_confirm.ts`
  - **Admin password generation**: Updated `generatePassword()` default from 16 to 20
  - **Frontend constants**: `PASSWORD_MAX_LENGTH = 20` in `customer_dashboard`
  - **Frontend UI**: Replaced hardcoded `maxLength={16}` with `PASSWORD_MAX_LENGTH` constant reference in `reset_password.tsx` and `forgot_password/page.tsx`, updated help text to "8-20 characters"

### Email Verification Timer 59s → 180s
- Extended the customer dashboard email verification countdown timer from 59 seconds to 180 seconds to align with the server-side `EMAIL_VERIFICATION_EXPIRATION_MINUTES=3` configuration
- The backend resend cooldown (`CAN_RESEND_CODE_INTERVAL_SECONDS = 60`) is intentionally unchanged

## Links (Issue References, etc, if there's any)

OKO-823