### PR TITLE
oko_sdk_svm: use workspace dep for oko-sdk-core

### DIFF
--- a/sdk/oko_sdk_svm/package.json
+++ b/sdk/oko_sdk_svm/package.json
@@ -36,7 +36,7 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "@oko-wallet/oko-sdk-core": "^0.1.2-alpha.11",
+    "@oko-wallet/oko-sdk-core": "workspace:*",
     "@oko-wallet/stdlib-js": "^0.0.2-rc.42",
     "@solana/wallet-standard-features": "^1.3.0",
     "@solana/web3.js": "^1.98.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11778,7 +11778,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@oko-wallet/oko-sdk-svm@workspace:sdk/oko_sdk_svm"
   dependencies:
-    "@oko-wallet/oko-sdk-core": "npm:^0.1.2-alpha.11"
+    "@oko-wallet/oko-sdk-core": "workspace:*"
     "@oko-wallet/stdlib-js": "npm:^0.0.2-rc.42"
     "@rollup/plugin-commonjs": "npm:^25.0.0"
     "@rollup/plugin-node-resolve": "npm:^15.0.0"


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Change `oko_sdk_svm`'s `@oko-wallet/oko-sdk-core` dependency from `^0.1.2-alpha.11` to `workspace:*`.

The published `alpha.11` package does not include the `setTheme` method recently added to `OkoWalletInterface`, causing `build_sdk` CI to fail when the SVM mock references it. Using `workspace:*` resolves against the local source (matching `oko_sdk_core_react_native`'s existing approach). Yarn replaces `workspace:*` with the real version on `npm publish`.

## Links (Issue References, etc, if there's any)

Fixes `build_sdk` CI failure: `TS2353: Object literal may only specify known properties, and 'setTheme' does not exist in type 'OkoWalletInterface'`