### PR TITLE
docs: add React Native SDK README and examples reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ step by email.
 | [@oko-wallet/oko-sdk-cosmos](sdk/oko_sdk_cosmos) | [![npm version](https://img.shields.io/npm/v/@oko-wallet/oko-sdk-cosmos.svg)](https://www.npmjs.com/package/@oko-wallet/oko-sdk-cosmos) |
 | [@oko-wallet/oko-sdk-eth](sdk/oko_sdk_eth)       | [![npm version](https://img.shields.io/npm/v/@oko-wallet/oko-sdk-eth.svg)](https://www.npmjs.com/package/@oko-wallet/oko-sdk-eth)       |
 | [@oko-wallet/oko-sdk-svm](sdk/oko_sdk_svm)       | [![npm version](https://img.shields.io/npm/v/@oko-wallet/oko-sdk-svm.svg)](https://www.npmjs.com/package/@oko-wallet/oko-sdk-svm)       |
+| [@oko-wallet/oko-sdk-core-react-native](sdk/oko_sdk_core_react_native) | [![npm version](https://img.shields.io/npm/v/@oko-wallet/oko-sdk-core-react-native.svg)](https://www.npmjs.com/package/@oko-wallet/oko-sdk-core-react-native) |
 
 ## How it works
 

--- a/apps/docs_web/docs/v0/sdk-usage/mobile/react-native-integration.md
+++ b/apps/docs_web/docs/v0/sdk-usage/mobile/react-native-integration.md
@@ -21,10 +21,10 @@ Native** — pass the RN wallet instance to their constructors:
 ```typescript
 import { useOkoWallet } from "@oko-wallet/oko-sdk-core-react-native";
 import { OkoEthWallet } from "@oko-wallet/oko-sdk-eth";
-import type { OkoWalletInterface } from "@oko-wallet/oko-sdk-core";
+
 
 const wallet = useOkoWallet();
-const eth = new OkoEthWallet(wallet as OkoWalletInterface);
+const eth = new OkoEthWallet(wallet);
 ```
 
 :::
@@ -285,12 +285,12 @@ handle all OS-browser transport automatically.
 import { useMemo } from "react";
 import { useOkoWallet } from "@oko-wallet/oko-sdk-core-react-native";
 import { OkoEthWallet } from "@oko-wallet/oko-sdk-eth";
-import type { OkoWalletInterface } from "@oko-wallet/oko-sdk-core";
+
 
 function EthExample() {
   const wallet = useOkoWallet();
   const eth = useMemo(
-    () => new OkoEthWallet(wallet as OkoWalletInterface),
+    () => new OkoEthWallet(wallet),
     [wallet],
   );
 
@@ -311,12 +311,12 @@ For full EVM API (transactions, typed data, EIP-1193 provider):
 import { useMemo } from "react";
 import { useOkoWallet } from "@oko-wallet/oko-sdk-core-react-native";
 import { OkoCosmosWallet } from "@oko-wallet/oko-sdk-cosmos";
-import type { OkoWalletInterface } from "@oko-wallet/oko-sdk-core";
+
 
 function CosmosExample() {
   const wallet = useOkoWallet();
   const cosmos = useMemo(
-    () => new OkoCosmosWallet(wallet as OkoWalletInterface),
+    () => new OkoCosmosWallet(wallet),
     [wallet],
   );
 
@@ -336,13 +336,13 @@ For full Cosmos API (signDirect, signAmino, signArbitrary, sendTx):
 import { useMemo } from "react";
 import { useOkoWallet } from "@oko-wallet/oko-sdk-core-react-native";
 import { OkoSvmWallet } from "@oko-wallet/oko-sdk-svm";
-import type { OkoWalletInterface } from "@oko-wallet/oko-sdk-core";
+
 
 function SolanaExample() {
   const wallet = useOkoWallet();
   const svm = useMemo(
     () =>
-      new OkoSvmWallet(wallet as OkoWalletInterface, {
+      new OkoSvmWallet(wallet, {
         chain_id: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       }),
     [wallet],

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,3 +20,8 @@ by following the instructions in the README.
   RainbowKit with Oko
 - **[Multi-Ecosystem React Example](multi_ecosystem_react)** — React + Vite with
   Oko for both Cosmos and EVM
+
+## React Native
+
+For React Native integration, see the
+**[React Native Integration Guide](https://docs.oko.app/docs/v0/sdk-usage/mobile/react-native-integration)**.

--- a/sdk/oko_sdk_core_react_native/README.md
+++ b/sdk/oko_sdk_core_react_native/README.md
@@ -1,0 +1,76 @@
+# @oko-wallet/oko-sdk-core-react-native
+
+React Native SDK for [Oko](https://oko.app) — an embedded wallet powered by
+MPC threshold signatures. Uses the OS browser (ASWebAuthenticationSession on
+iOS, Chrome Custom Tabs on Android) for authentication and signing instead of
+a WebView.
+
+## Installation
+
+```bash
+npm install @oko-wallet/oko-sdk-core-react-native
+```
+
+### Peer Dependencies
+
+| Package | Version | Required |
+| --- | --- | --- |
+| `react` | >=18 | Yes |
+| `react-native` | >=0.70 | Yes |
+| `@react-native-async-storage/async-storage` | >=1.17 | Yes |
+| `react-native-get-random-values` | >=1 | Yes |
+| `expo-web-browser` | >=14 | No (Expo projects) |
+| `react-native-inappbrowser-reborn` | >=3 | No (Bare RN projects) |
+
+One of `expo-web-browser` or `react-native-inappbrowser-reborn` is required.
+
+## Usage
+
+```tsx
+import { OkoWalletProvider, useOkoWallet } from "@oko-wallet/oko-sdk-core-react-native";
+
+function App() {
+  return (
+    <OkoWalletProvider apiKey="your-api-key">
+      <SignIn />
+    </OkoWalletProvider>
+  );
+}
+
+function SignIn() {
+  const wallet = useOkoWallet();
+
+  const handleSignIn = async () => {
+    await wallet.signIn("google");
+    const info = await wallet.getWalletInfo();
+    console.log("Signed in:", info?.email);
+  };
+
+  return <Button title="Sign In" onPress={handleSignIn} />;
+}
+```
+
+### Chain-Specific SDKs
+
+The chain SDKs work with the RN wallet instance:
+
+```bash
+npm install @oko-wallet/oko-sdk-eth     # Ethereum / EVM
+npm install @oko-wallet/oko-sdk-cosmos  # Cosmos
+npm install @oko-wallet/oko-sdk-svm     # Solana
+```
+
+```tsx
+import { useOkoWallet } from "@oko-wallet/oko-sdk-core-react-native";
+import { OkoEthWallet } from "@oko-wallet/oko-sdk-eth";
+
+const wallet = useOkoWallet();
+const eth = new OkoEthWallet(wallet);
+```
+
+## Documentation
+
+For the complete setup guide, platform configuration, and API reference:
+
+- [React Native Integration](https://docs.oko.app/docs/v0/sdk-usage/mobile/react-native-integration)
+- [React Native Platform Setup](https://docs.oko.app/docs/v0/sdk-usage/mobile/react-native-platform-setup)


### PR DESCRIPTION
# Pull Request

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Add a proper README for `@oko-wallet/oko-sdk-core-react-native` npm package and add a React Native section to the examples index.

- **`sdk/oko_sdk_core_react_native/README.md`** (new): Package README visible on npm. Includes install command, peer dependencies table, basic usage example (`OkoWalletProvider` + `useOkoWallet`), chain SDK interop, and links to the full docs at docs.oko.app.
- **`examples/README.md`**: Added a React Native section linking to the docs integration guide.

## Links (Issue References, etc, if there's any)

N/A