### PR TITLE
ci: add attached_mobile_host_web to Vercel deploy targets

### DIFF
--- a/internals/ci/src/cmds/deploy.ts
+++ b/internals/ci/src/cmds/deploy.ts
@@ -27,6 +27,9 @@ const APP_CONFIGS = {
   "oko-user-dashboard": {
     path: path.join(paths.root, "apps/user_dashboard"),
   },
+  "oko-attached-mobile-host-web": {
+    path: paths.attached_mobile_host_web,
+  },
   "oko-sandbox-evm": {
     path: path.join(paths.root, "sandbox/sandbox_evm"),
   },


### PR DESCRIPTION
# Pull Request

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Add `oko-attached-mobile-host-web` to the `APP_CONFIGS` in `internals/ci/src/cmds/deploy.ts` so it can be deployed via `yarn ci deploy --app oko-attached-mobile-host-web`.

The path (`paths.attached_mobile_host_web`) already existed in `paths.ts` — this change only registers the app as a deployable Vercel target.

## Links (Issue References, etc, if there's any)

N/A