### PR TITLE
ci: add attached_mobile_host_web to deploy_oko_apps workflow

### DIFF
--- a/.github/workflows/deploy_oko_apps.yml
+++ b/.github/workflows/deploy_oko_apps.yml
@@ -6,13 +6,14 @@ env:
   VERCEL_PRJ_ID__USER_DASHBOARD: ${{ secrets.VERCEL_PRJ_ID__USER_DASHBOARD }}
   VERCEL_PRJ_ID__ADMIN_WEB: ${{ secrets.VERCEL_PRJ_ID__ADMIN_WEB }}
   VERCEL_PRJ_ID__DOCS_WEB: ${{ secrets.VERCEL_PRJ_ID__DOCS_WEB }}
+  VERCEL_PRJ_ID__ATTACHED_MOBILE_HOST_WEB: ${{ secrets.VERCEL_PRJ_ID__ATTACHED_MOBILE_HOST_WEB }}
 on:
   workflow_dispatch:
     inputs:
       git_tag:
         description: >
           "Git tag (format: <app>/develop/v0.0.1 or <app>/release/v0.0.1).
-          Apps: demo_web, user_dashboard, ct_dashboard, admin_web, docs_web"
+          Apps: demo_web, user_dashboard, ct_dashboard, admin_web, docs_web, attached_mobile_host_web"
         required: true
         type: string
 
@@ -84,6 +85,10 @@ jobs:
               ;;
             docs_web)
               echo "VERCEL_PROJECT_ID=$VERCEL_PRJ_ID__DOCS_WEB" >> \
+                "$GITHUB_ENV"
+              ;;
+            attached_mobile_host_web)
+              echo "VERCEL_PROJECT_ID=$VERCEL_PRJ_ID__ATTACHED_MOBILE_HOST_WEB" >> \
                 "$GITHUB_ENV"
               ;;
             *)

--- a/internals/github/dist/validate_git_tag.js
+++ b/internals/github/dist/validate_git_tag.js
@@ -4,6 +4,7 @@ const VALID_APPS = {
     ct_dashboard: ["develop", "release"],
     admin_web: ["develop", "release"],
     attached: ["develop", "release"],
+    attached_mobile_host_web: ["develop", "release"],
     docs_web: ["release"],
 };
 const APP_TAG_PATTERN = /^([a-z_]+)\/(develop|release)\/v\d+\.\d+\.\d+$/;

--- a/internals/github/src/validate_git_tag.ts
+++ b/internals/github/src/validate_git_tag.ts
@@ -7,6 +7,7 @@ const VALID_APPS: Record<string, Env[]> = {
   ct_dashboard: ["develop", "release"],
   admin_web: ["develop", "release"],
   attached: ["develop", "release"],
+  attached_mobile_host_web: ["develop", "release"],
   docs_web: ["release"],
 };
 


### PR DESCRIPTION
# Pull Request

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Add `attached_mobile_host_web` to the `deploy_oko_apps.yml` GitHub Actions workflow so it can be deployed via the same tag-based workflow as other apps.

Changes:
- Add `VERCEL_PRJ_ID__ATTACHED_MOBILE_HOST_WEB` secret reference
- Add `attached_mobile_host_web` to the supported apps list in the workflow description
- Add `attached_mobile_host_web` case to the Vercel project ID mapping

**Prerequisite:** Add `VERCEL_PRJ_ID__ATTACHED_MOBILE_HOST_WEB` to GitHub Secrets with the Vercel project ID.

**Deploy tag format:** `attached_mobile_host_web/develop/v0.0.1` or `attached_mobile_host_web/release/v0.0.1`

## Links (Issue References, etc, if there's any)

Related: #377