### PR TITLE
attached_mobile_host_web: add vercel.json SPA rewrite

### DIFF
--- a/apps/attached_mobile_host_web/vercel.json
+++ b/apps/attached_mobile_host_web/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
# Pull Request

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Add `vercel.json` with SPA rewrite rule to `attached_mobile_host_web`. Without this, direct navigation to sub-paths like `/mobile/rpc` or `/mobile/login` returns Vercel's 404 page since Vite builds a single `index.html` with client-side routing.

Matches the existing configuration in `oko_attached/vercel.json`.

## Links (Issue References, etc, if there's any)

N/A