### PR TITLE
oko_attached: fix mobile OAuth redirect_uri mismatch for PKCE providers

### DIFF
--- a/embed/oko_attached/src/store/app.ts
+++ b/embed/oko_attached/src/store/app.ts
@@ -33,6 +33,7 @@ interface PerOriginState {
   seedEd25519: string | null;
   nonce: string | null;
   codeVerifier: string | null;
+  oauthRedirectOrigin: string | null;
   authToken: string | null;
   wallet: WalletState | null;
   ed25519Wallet: Ed25519WalletState | null;
@@ -49,6 +50,9 @@ interface AppActions {
 
   getCodeVerifier: (storageKey: string) => string | null;
   setCodeVerifier: (storageKey: string, codeVerifier: string | null) => void;
+
+  getOauthRedirectOrigin: (storageKey: string) => string | null;
+  setOauthRedirectOrigin: (storageKey: string, origin: string | null) => void;
 
   getWallet: (storageKey: string) => WalletState | null;
   setWallet: (storageKey: string, wallet: WalletState | null) => void;
@@ -166,6 +170,7 @@ export const useAppState = create(
               seedEd25519: null,
               nonce: null,
               codeVerifier: null,
+              oauthRedirectOrigin: null,
               authToken: null,
               wallet: null,
               ed25519Wallet: null,
@@ -210,6 +215,23 @@ export const useAppState = create(
       },
       getCodeVerifier: (storageKey: string) => {
         return get().perOrigin[storageKey]?.codeVerifier;
+      },
+      setOauthRedirectOrigin: (
+        storageKey: string,
+        oauthRedirectOrigin: string | null,
+      ) => {
+        set({
+          perOrigin: {
+            ...get().perOrigin,
+            [storageKey]: {
+              ...get().perOrigin[storageKey],
+              oauthRedirectOrigin,
+            },
+          },
+        });
+      },
+      getOauthRedirectOrigin: (storageKey: string) => {
+        return get().perOrigin[storageKey]?.oauthRedirectOrigin ?? null;
       },
       getKeyshare_1: (storageKey: string) => {
         return get().perOrigin[storageKey]?.keyshare_1;

--- a/embed/oko_attached/src/window_msgs/generate_oauth_url.ts
+++ b/embed/oko_attached/src/window_msgs/generate_oauth_url.ts
@@ -131,6 +131,7 @@ async function buildOAuthUrl(
   // X, Discord, GitHub use PKCE
   const { codeVerifier, codeChallenge } = await createPkcePair();
   appState.setCodeVerifier(storageKey, codeVerifier);
+  appState.setOauthRedirectOrigin(storageKey, redirectBaseOrigin);
 
   switch (provider) {
     case "x":

--- a/embed/oko_attached/src/window_msgs/oauth_info_pass/validate_social_login.ts
+++ b/embed/oko_attached/src/window_msgs/oauth_info_pass/validate_social_login.ts
@@ -36,7 +36,9 @@ async function validateOAuthPayloadOfX(
     };
   }
 
-  const redirectUri = `${window.location.origin}/x/callback`;
+  const redirectOrigin =
+    appState.getOauthRedirectOrigin(storageKey) ?? window.location.origin;
+  const redirectUri = `${redirectOrigin}/x/callback`;
 
   const tokenRes = await getAccessTokenOfX(
     payload.code,
@@ -69,6 +71,7 @@ async function validateOAuthPayloadOfX(
   const tokenInfo = tokenRes.data;
 
   appState.setCodeVerifier(storageKey, null);
+  appState.setOauthRedirectOrigin(storageKey, null);
 
   return {
     success: true,
@@ -114,7 +117,9 @@ async function validateOAuthPayloadOfDiscord(
     };
   }
 
-  const redirectUri = `${window.location.origin}/discord/callback`;
+  const redirectOrigin =
+    appState.getOauthRedirectOrigin(storageKey) ?? window.location.origin;
+  const redirectUri = `${redirectOrigin}/discord/callback`;
 
   const tokenRes = await getAccessTokenOfDiscordWithPKCE(
     payload.code,
@@ -140,6 +145,7 @@ async function validateOAuthPayloadOfDiscord(
   const userInfo = verifyIdTokenRes.data;
 
   appState.setCodeVerifier(storageKey, null);
+  appState.setOauthRedirectOrigin(storageKey, null);
 
   return {
     success: true,
@@ -163,7 +169,9 @@ async function validateOAuthPayloadOfGithub(
     };
   }
 
-  const redirectUri = `${window.location.origin}/github/callback`;
+  const redirectOrigin =
+    appState.getOauthRedirectOrigin(storageKey) ?? window.location.origin;
+  const redirectUri = `${redirectOrigin}/github/callback`;
 
   const tokenRes = await getAccessTokenOfGithub(
     payload.code,
@@ -189,6 +197,7 @@ async function validateOAuthPayloadOfGithub(
   const userInfo = verifyIdTokenRes.data;
 
   appState.setCodeVerifier(storageKey, null);
+  appState.setOauthRedirectOrigin(storageKey, null);
 
   return {
     success: true,


### PR DESCRIPTION
# Pull Request

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Fix OAuth token exchange failure for mobile OS browser flows (X, Discord, GitHub).

**Root cause:** During mobile OAuth, the authorization step sets `redirect_uri` to the mobile host origin (`https://mobile.oko.app/x/callback`), but the token exchange step inside the `oko_attached` iframe uses `window.location.origin` (`https://attached.oko.app/x/callback`). OAuth requires exact match, causing a 400 error.

**Fix:** Store the `redirectBaseOrigin` used during authorization in the Zustand per-origin state (alongside `codeVerifier`), then retrieve it during token exchange with a `window.location.origin` fallback. This ensures the same origin is used in both steps.

- Web OAuth is unaffected (stored origin = `window.location.origin` = same as before)
- Google OAuth is unaffected (uses implicit flow, no token exchange)

## Links (Issue References, etc, if there's any)

N/A