### PR TITLE
docs: mark Telegram sign-in as coming soon

### DIFF
--- a/apps/docs_web/docs/v0/getting-started/integration-overview.md
+++ b/apps/docs_web/docs/v0/getting-started/integration-overview.md
@@ -9,7 +9,7 @@ Oko can be used alongside existing wallet connection methods, including the
 Keplr browser extension and mobile app.
 
 Integration is simple. Just add social login to your onboarding flow and you're
-ready to go. We support Google, email, GitHub, X, Discord, and Telegram login.
+ready to go. We support Google, email, GitHub, X, and Discord login. Telegram support is coming soon.
 We also plan to allow users to connect wallets they already have installed, such
 as Keplr and MetaMask.
 

--- a/apps/docs_web/docs/v0/index.md
+++ b/apps/docs_web/docs/v0/index.md
@@ -120,7 +120,7 @@ dashboards.
 - GitHub
 - Discord
 - X (Twitter)
-- Telegram
+- Telegram (coming soon)
 
 **Oko SDK**
 

--- a/apps/docs_web/docs/v0/sdk-usage/cosmos-kit-integration.md
+++ b/apps/docs_web/docs/v0/sdk-usage/cosmos-kit-integration.md
@@ -131,8 +131,8 @@ When connecting, users can select their preferred login provider from a modal:
 - Google OAuth
 - Email/passwordless
 - X (Twitter) OAuth
-- Telegram OAuth
 - Discord OAuth
+- Telegram OAuth (coming soon)
 
 ## Next Steps
 

--- a/apps/docs_web/docs/v0/sdk-usage/interchain-kit-integration.md
+++ b/apps/docs_web/docs/v0/sdk-usage/interchain-kit-integration.md
@@ -123,8 +123,8 @@ When connecting, users can select their preferred login provider from a modal:
 - Google OAuth
 - Email/passwordless
 - X (Twitter) OAuth
-- Telegram OAuth
 - Discord OAuth
+- Telegram OAuth (coming soon)
 
 ## Signing Transactions
 

--- a/apps/docs_web/docs/v0/sdk-usage/mobile/react-native-integration.md
+++ b/apps/docs_web/docs/v0/sdk-usage/mobile/react-native-integration.md
@@ -169,7 +169,7 @@ AsyncStorage state is restored.
 ### Sign In
 
 ```typescript
-// type: "google" | "email" | "discord" | "github" | "x" | "telegram"
+// type: "google" | "email" | "discord" | "github" | "x"
 await wallet.signIn("google");
 ```
 
@@ -182,7 +182,8 @@ await wallet.signIn("google");
 | `"discord"` | Discord OAuth     |
 | `"github"`  | GitHub OAuth      |
 | `"x"`       | X (Twitter) OAuth |
-| `"telegram"`| Telegram OAuth    |
+
+> Telegram sign-in support is coming soon.
 
 Calling `signIn()` opens the OS browser for the OAuth flow. On iOS and Android
 fallback flows, the browser returns via your configured `redirectScheme`. On
@@ -199,7 +200,7 @@ function SignInButtons() {
   const wallet = useOkoWallet();
 
   const handleSignIn = async (
-    type: "google" | "email" | "discord" | "github" | "x" | "telegram",
+    type: "google" | "email" | "discord" | "github" | "x",
   ) => {
     try {
       await wallet.signIn(type);
@@ -229,10 +230,6 @@ function SignInButtons() {
         onPress={() => handleSignIn("github")}
       />
       <Button title="Sign in with X" onPress={() => handleSignIn("x")} />
-      <Button
-        title="Sign in with Telegram"
-        onPress={() => handleSignIn("telegram")}
-      />
     </View>
   );
 }


### PR DESCRIPTION
# Pull Request

- [x] I've read `CONTRIBUTING.md` and followed the guidelines.

## Summary

Mark Telegram sign-in as "coming soon" across all documentation pages. Telegram OAuth requires additional work before release, so this update sets expectations for users while keeping the feature visible.

Changes across 5 docs files:
- `index.md` — "Telegram (coming soon)"
- `integration-overview.md` — separated from supported providers list
- `interchain-kit-integration.md` — "(coming soon)" label
- `cosmos-kit-integration.md` — "(coming soon)" label
- `react-native-integration.md` — removed from sign-in type union, table, and example; added "coming soon" note

## Links (Issue References, etc, if there's any)

N/A