### PR TITLE
oko_attached: bypass storageKey guard for open_modal to fix popup race condition

### DIFF
--- a/embed/oko_attached/src/window_msgs/index.ts
+++ b/embed/oko_attached/src/window_msgs/index.ts
@@ -129,6 +129,18 @@ export function makeMsgHandler() {
     if (!isFromProxy) {
       memState.setAppName(appName);
     }
+    // open_modal does not require storageKey — it only stores the modal
+    // request in MemoryState.  Handle it before the storageKey guard so
+    // that popup windows (where init is still in progress when the SDK
+    // sends open_modal right after popup_ready) are not rejected.
+    if (message.msg_type === "open_modal") {
+      handleOpenModal(
+        { port, hostOrigin: event.origin, appName, storageKey: "" },
+        message,
+      );
+      return;
+    }
+
     const storageKey = memState.storageKey;
     if (!storageKey) {
       console.warn(
@@ -195,11 +207,6 @@ export function makeMsgHandler() {
 
       case "get_auth_type": {
         await handleGetAuthType(ctx);
-        break;
-      }
-
-      case "open_modal": {
-        await handleOpenModal(ctx, message);
         break;
       }
 


### PR DESCRIPTION
## 이메일/텔레그램 로그인 팝업이 열리자마자 닫히는 버그 수정.

4172ff348 (mobile: stabilize RN browser flow)에서 storageKey 미초기화 시 메시지를 reject하는 가드가 추가됨. 팝업 컨텍스트에서는 popup_ready가 useInitializeApp 완료 전에 전송되어, SDK가 보낸 open_modal 메시지가 storageKey 가드에 의해 즉시 reject → openModal이 return → finally에서 closeModal() 호출 → 팝업 닫힘.

open_modal은 storageKey를 사용하지 않으므로 (MemoryState에 modal request를 저장하기만 함), storageKey 가드 이전에 처리하도록 변경.

## Root Cause

popup_ready 전송 (useNotifyPopupReady)
  → SDK가 open_modal 전송
    → 팝업의 메시지 핸들러: storageKey === null (init 미완료)
      → 즉시 open_modal_ack { success: false } 반환
        → SDK openModal return → finally → closeModal() → 팝업 닫힘