### PR TITLE
OKO-770

### DIFF
--- a/.github/workflows/deploy_oko_apps.yml
+++ b/.github/workflows/deploy_oko_apps.yml
@@ -129,4 +129,27 @@ jobs:
         run: vercel build --yes ${{ steps.deploy_env.outputs.vercel_build_flag }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt ${{ steps.deploy_env.outputs.vercel_deploy_flag }} --token=${{ secrets.VERCEL_TOKEN }}
+        id: vercel_deploy
+        run: |
+          URL=$(vercel deploy --prebuilt ${{ steps.deploy_env.outputs.vercel_deploy_flag }} --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Alias deployment
+        if: contains(inputs.git_tag, '/alpha/')
+        env:
+          ALIAS_DEMO_WEB: ${{ secrets.VERCEL_ALIAS_DEMO_WEB_ALPHA }}
+          ALIAS_CT_DASHBOARD: ${{ secrets.VERCEL_ALIAS_CT_DASHBOARD_ALPHA }}
+          ALIAS_ADMIN_WEB: ${{ secrets.VERCEL_ALIAS_ADMIN_WEB_ALPHA }}
+          ALIAS_USER_DASHBOARD: ${{ secrets.VERCEL_ALIAS_USER_DASHBOARD_ALPHA }}
+        run: |
+          case "${{ steps.deploy_env.outputs.vercel_app }}" in
+            demo_web) ALIAS_DOMAIN="$ALIAS_DEMO_WEB" ;;
+            ct_dashboard) ALIAS_DOMAIN="$ALIAS_CT_DASHBOARD" ;;
+            admin_web) ALIAS_DOMAIN="$ALIAS_ADMIN_WEB" ;;
+            user_dashboard) ALIAS_DOMAIN="$ALIAS_USER_DASHBOARD" ;;
+            *) echo "No alias configured for this app"; exit 0 ;;
+          esac
+          if [ -n "$ALIAS_DOMAIN" ]; then
+            vercel alias set "${{ steps.vercel_deploy.outputs.url }}" "$ALIAS_DOMAIN" \
+              --scope=keplrwallet --token=${{ secrets.VERCEL_TOKEN }}
+          fi

--- a/.github/workflows/deploy_oko_apps.yml
+++ b/.github/workflows/deploy_oko_apps.yml
@@ -141,12 +141,14 @@ jobs:
           ALIAS_CT_DASHBOARD: ${{ secrets.VERCEL_ALIAS_CT_DASHBOARD_ALPHA }}
           ALIAS_ADMIN_WEB: ${{ secrets.VERCEL_ALIAS_ADMIN_WEB_ALPHA }}
           ALIAS_USER_DASHBOARD: ${{ secrets.VERCEL_ALIAS_USER_DASHBOARD_ALPHA }}
+          ALIAS_ATTACHED_MOBILE_HOST_WEB: ${{ secrets.VERCEL_ALIAS_ATTACHED_MOBILE_HOST_WEB_ALPHA }}
         run: |
           case "${{ steps.deploy_env.outputs.vercel_app }}" in
             demo_web) ALIAS_DOMAIN="$ALIAS_DEMO_WEB" ;;
             ct_dashboard) ALIAS_DOMAIN="$ALIAS_CT_DASHBOARD" ;;
             admin_web) ALIAS_DOMAIN="$ALIAS_ADMIN_WEB" ;;
             user_dashboard) ALIAS_DOMAIN="$ALIAS_USER_DASHBOARD" ;;
+            attached_mobile_host_web) ALIAS_DOMAIN="$ALIAS_ATTACHED_MOBILE_HOST_WEB" ;;
             *) echo "No alias configured for this app"; exit 0 ;;
           esac
           if [ -n "$ALIAS_DOMAIN" ]; then

--- a/.github/workflows/deploy_oko_apps.yml
+++ b/.github/workflows/deploy_oko_apps.yml
@@ -12,7 +12,7 @@ on:
     inputs:
       git_tag:
         description: >
-          "Git tag (format: <app>/develop/v0.0.1 or <app>/release/v0.0.1).
+          "Git tag (format: <app>/alpha/v0.0.1, <app>/develop/v0.0.1, or <app>/release/v0.0.1).
           Apps: demo_web, user_dashboard, ct_dashboard, admin_web, docs_web, attached_mobile_host_web"
         required: true
         type: string
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     environment:
-      name: ${{ contains(inputs.git_tag, '/release/') && 'Production' || 'Preview' }}
+      name: ${{ contains(inputs.git_tag, '/release/') && 'Production' || contains(inputs.git_tag, '/alpha/') && 'Alpha' || 'Develop' }}
     steps:
       - name: Checkout self repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy_oko_attached.yml
+++ b/.github/workflows/deploy_oko_attached.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       git_tag:
         description: >
-          "Git tag (format: attached/develop/v0.0.1 or attached/release/v0.0.1)"
+          "Git tag (format: attached/alpha/v0.0.1, attached/develop/v0.0.1, or attached/release/v0.0.1)"
         required: true
         type: string
 
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     environment:
-      name: ${{ contains(inputs.git_tag, '/release/') && 'Production' || 'Preview' }}
+      name: ${{ contains(inputs.git_tag, '/release/') && 'Production' || contains(inputs.git_tag, '/alpha/') && 'Alpha' || 'Develop' }}
     steps:
       - name: Checkout self repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy_oko_attached.yml
+++ b/.github/workflows/deploy_oko_attached.yml
@@ -114,4 +114,14 @@ jobs:
         run: vercel build --yes ${{ steps.deploy_env.outputs.vercel_build_flag }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt ${{ steps.deploy_env.outputs.vercel_deploy_flag }} --token=${{ secrets.VERCEL_TOKEN }}
+        id: vercel_deploy
+        run: |
+          URL=$(vercel deploy --prebuilt ${{ steps.deploy_env.outputs.vercel_deploy_flag }} --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Alias deployment
+        if: contains(inputs.git_tag, '/alpha/')
+        run: |
+          vercel alias set "${{ steps.vercel_deploy.outputs.url }}" \
+            "${{ secrets.VERCEL_ALIAS_ATTACHED_ALPHA }}" \
+            --scope=keplrwallet --token=${{ secrets.VERCEL_TOKEN }}

--- a/internals/ci/src/cmds/deploy.ts
+++ b/internals/ci/src/cmds/deploy.ts
@@ -45,7 +45,7 @@ function listDeployableApps(): void {
   });
 }
 
-type DeploymentEnv = "preview" | "develop" | "prod";
+type DeploymentEnv = "alpha" | "develop" | "prod";
 
 interface DeployOptions {
   app?: keyof typeof APP_CONFIGS;
@@ -53,7 +53,7 @@ interface DeployOptions {
 }
 
 export async function deploy(options: DeployOptions) {
-  const { app, env = "preview" } = options;
+  const { app, env = "alpha" } = options;
 
   if (!app) {
     listDeployableApps();
@@ -61,7 +61,7 @@ export async function deploy(options: DeployOptions) {
     process.exit(1);
   }
 
-  const validEnvs: DeploymentEnv[] = ["preview", "develop", "prod"];
+  const validEnvs: DeploymentEnv[] = ["alpha", "develop", "prod"];
   if (!validEnvs.includes(env)) {
     console.error(
       chalk.red(
@@ -108,6 +108,8 @@ export async function deploy(options: DeployOptions) {
     buildArgs.push("--prod");
   } else if (env === "develop") {
     buildArgs.push("--target=develop");
+  } else if (env === "alpha") {
+    buildArgs.push("--target=preview");
   }
 
   const buildRet = spawnSync("vercel", buildArgs, {
@@ -124,6 +126,8 @@ export async function deploy(options: DeployOptions) {
     deployArgs.push("--prod");
   } else if (env === "develop") {
     deployArgs.push("--target=develop");
+  } else if (env === "alpha") {
+    deployArgs.push("--target=preview");
   }
 
   const deployRet = spawnSync("vercel", deployArgs, {

--- a/internals/ci/src/cmds/deploy.ts
+++ b/internals/ci/src/cmds/deploy.ts
@@ -8,34 +8,18 @@ import { paths } from "@oko-wallet-ci/paths";
 
 const VERCEL_SCOPE = "keplrwallet";
 
-const APP_CONFIGS = {
-  "oko-demo-web": {
-    path: paths.demo_web,
-  },
-  "oko-attached": {
-    path: paths.oko_attached,
-  },
-  "oko-customer-dashboard": {
-    path: paths.ct_dashboard_web,
-  },
-  "oko-docs-web": {
-    path: path.join(paths.root, "apps/docs_web"),
-  },
-  "oko-admin-web": {
-    path: paths.oko_admin_web,
-  },
-  "oko-user-dashboard": {
-    path: path.join(paths.root, "apps/user_dashboard"),
-  },
-  "oko-attached-mobile-host-web": {
-    path: paths.attached_mobile_host_web,
-  },
-  "oko-sandbox-evm": {
-    path: path.join(paths.root, "sandbox/sandbox_evm"),
-  },
-  "oko-sandbox-sol": {
-    path: path.join(paths.root, "sandbox/sandbox_sol"),
-  },
+type DeploymentEnv = "alpha" | "develop" | "prod";
+
+const APP_CONFIGS: Record<string, { path: string }> = {
+  "oko-demo-web": { path: paths.demo_web },
+  "oko-attached": { path: paths.oko_attached },
+  "oko-customer-dashboard": { path: paths.ct_dashboard_web },
+  "oko-docs-web": { path: path.join(paths.root, "apps/docs_web") },
+  "oko-admin-web": { path: paths.oko_admin_web },
+  "oko-user-dashboard": { path: path.join(paths.root, "apps/user_dashboard") },
+  "oko-attached-mobile-host-web": { path: paths.attached_mobile_host_web },
+  "oko-sandbox-evm": { path: path.join(paths.root, "sandbox/sandbox_evm") },
+  "oko-sandbox-sol": { path: path.join(paths.root, "sandbox/sandbox_sol") },
 };
 
 function listDeployableApps(): void {
@@ -45,10 +29,8 @@ function listDeployableApps(): void {
   });
 }
 
-type DeploymentEnv = "alpha" | "develop" | "prod";
-
 interface DeployOptions {
-  app?: keyof typeof APP_CONFIGS;
+  app?: string;
   env?: DeploymentEnv;
 }
 
@@ -132,8 +114,27 @@ export async function deploy(options: DeployOptions) {
 
   const deployRet = spawnSync("vercel", deployArgs, {
     cwd: paths.root,
-    stdio: "inherit",
+    stdio: ["inherit", "pipe", "inherit"],
+    encoding: "utf8",
   });
   expectSuccess(deployRet, "Vercel deployment failed");
-  console.log(chalk.bold.green("\n✓ Deployment completed successfully!"));
+  const deploymentUrl = deployRet.stdout.trim();
+  console.log(chalk.green(`✓ Deployed: ${deploymentUrl}\n`));
+  console.log(chalk.bold.green("✓ Deployment completed successfully!"));
+
+  // Step 4: Alias (if VERCEL_ALIAS_DOMAIN env var is set)
+  const aliasDomain = process.env.VERCEL_ALIAS_DOMAIN;
+  if (aliasDomain) {
+    console.log(chalk.blue("\nAliasing"), `${deploymentUrl} → ${aliasDomain}`);
+    const aliasRet = spawnSync(
+      "vercel",
+      ["alias", "set", deploymentUrl, aliasDomain, `--scope=${VERCEL_SCOPE}`],
+      {
+        cwd: paths.root,
+        stdio: "inherit",
+      },
+    );
+    expectSuccess(aliasRet, "Vercel alias failed");
+    console.log(chalk.bold.green(`✓ Aliased to ${aliasDomain}`));
+  }
 }

--- a/internals/ci/src/main.ts
+++ b/internals/ci/src/main.ts
@@ -86,8 +86,8 @@ async function main() {
     .option("--app <app>", "App to deploy")
     .option(
       "--env <env>",
-      "Deployment environment (preview|develop|prod). Default: preview",
-      "preview",
+      "Deployment environment (alpha|develop|prod). Default: alpha",
+      "alpha",
     )
     .action(deploy);
 

--- a/internals/github/dist/determine_deploy_env.js
+++ b/internals/github/dist/determine_deploy_env.js
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 // App tag format: <app>/<env>/v<version>
 // e.g. demo_web/develop/v0.0.1, attached/release/v1.0.0
-const APP_TAG_PATTERN = /^([a-z_]+)\/(develop|release)\/v(\d+\.\d+\.\d+)$/;
+const APP_TAG_PATTERN = /^([a-z_]+)\/(alpha|develop|release)\/v(\d+\.\d+\.\d+)$/;
 function parseTag(tag) {
     const match = APP_TAG_PATTERN.exec(tag);
     if (!match) {
@@ -34,6 +34,11 @@ async function main() {
         vercelEnv = "production";
         vercelBuildFlag = "--prod";
         vercelDeployFlag = "--prod";
+    }
+    else if (parsed.env === "alpha") {
+        vercelEnv = "preview";
+        vercelBuildFlag = "--target=preview";
+        vercelDeployFlag = "--target=preview";
     }
     else {
         vercelEnv = "develop";

--- a/internals/github/dist/validate_git_tag.js
+++ b/internals/github/dist/validate_git_tag.js
@@ -1,13 +1,13 @@
 const VALID_APPS = {
-    demo_web: ["develop", "release"],
-    user_dashboard: ["develop", "release"],
-    ct_dashboard: ["develop", "release"],
-    admin_web: ["develop", "release"],
-    attached: ["develop", "release"],
-    attached_mobile_host_web: ["develop", "release"],
+    demo_web: ["alpha", "develop", "release"],
+    user_dashboard: ["alpha", "develop", "release"],
+    ct_dashboard: ["alpha", "develop", "release"],
+    admin_web: ["alpha", "develop", "release"],
+    attached: ["alpha", "develop", "release"],
+    attached_mobile_host_web: ["alpha", "develop", "release"],
     docs_web: ["release"],
 };
-const APP_TAG_PATTERN = /^([a-z_]+)\/(develop|release)\/v\d+\.\d+\.\d+$/;
+const APP_TAG_PATTERN = /^([a-z_]+)\/(alpha|develop|release)\/v\d+\.\d+\.\d+$/;
 async function main() {
     const tag = process.env.GIT_TAG;
     if (tag === undefined || tag.length < 1) {

--- a/internals/github/src/determine_deploy_env.ts
+++ b/internals/github/src/determine_deploy_env.ts
@@ -2,11 +2,12 @@ import * as fs from "node:fs";
 
 // App tag format: <app>/<env>/v<version>
 // e.g. demo_web/develop/v0.0.1, attached/release/v1.0.0
-const APP_TAG_PATTERN = /^([a-z_]+)\/(develop|release)\/v(\d+\.\d+\.\d+)$/;
+const APP_TAG_PATTERN =
+  /^([a-z_]+)\/(alpha|develop|release)\/v(\d+\.\d+\.\d+)$/;
 
 interface ParsedTag {
   app: string;
-  env: "develop" | "release";
+  env: "alpha" | "develop" | "release";
   version: string;
 }
 
@@ -23,7 +24,7 @@ function parseTag(tag: string): ParsedTag {
 
   return {
     app: match[1],
-    env: match[2] as "develop" | "release",
+    env: match[2] as "alpha" | "develop" | "release",
     version: match[3],
   };
 }
@@ -52,6 +53,10 @@ async function main() {
     vercelEnv = "production";
     vercelBuildFlag = "--prod";
     vercelDeployFlag = "--prod";
+  } else if (parsed.env === "alpha") {
+    vercelEnv = "preview";
+    vercelBuildFlag = "--target=preview";
+    vercelDeployFlag = "--target=preview";
   } else {
     vercelEnv = "develop";
     vercelBuildFlag = "--target=develop";

--- a/internals/github/src/validate_git_tag.ts
+++ b/internals/github/src/validate_git_tag.ts
@@ -1,17 +1,17 @@
 // App tag format: <app>/<env>/v<version>
-type Env = "develop" | "release";
+type Env = "alpha" | "develop" | "release";
 
 const VALID_APPS: Record<string, Env[]> = {
-  demo_web: ["develop", "release"],
-  user_dashboard: ["develop", "release"],
-  ct_dashboard: ["develop", "release"],
-  admin_web: ["develop", "release"],
-  attached: ["develop", "release"],
-  attached_mobile_host_web: ["develop", "release"],
+  demo_web: ["alpha", "develop", "release"],
+  user_dashboard: ["alpha", "develop", "release"],
+  ct_dashboard: ["alpha", "develop", "release"],
+  admin_web: ["alpha", "develop", "release"],
+  attached: ["alpha", "develop", "release"],
+  attached_mobile_host_web: ["alpha", "develop", "release"],
   docs_web: ["release"],
 };
 
-const APP_TAG_PATTERN = /^([a-z_]+)\/(develop|release)\/v\d+\.\d+\.\d+$/;
+const APP_TAG_PATTERN = /^([a-z_]+)\/(alpha|develop|release)\/v\d+\.\d+\.\d+$/;
 
 async function main() {
   const tag = process.env.GIT_TAG;


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [ ] I’ve read `CONTRIBUTING.md` and followed the guidelines.

## Summary

`yarn ci deploy` 및 GitHub Actions 배포 워크플로우에 alpha 환경을 추가하고, alpha 배포 시 커스텀 도메인 alias를 자동으로 설정하도록 구성

### Changes

- `deploy.ts`의 `DeploymentEnv` 타입을 `preview → alpha`로 교체하고, alpha 환경을 Vercel Preview에 매핑 (`--target=preview`)
- `validate_git_tag.ts` / `determine_deploy_env.ts`에 `alpha` 환경 지원 추가 — 태그 형식 `<app>/alpha/v<version>` 허용
- GitHub Actions 워크플로우 environment 분기를 3-way로 업데이트 (`Production` / `Alpha` / `Develop`)
- alpha 배포 후 `vercel alias set`으로 커스텀 도메인을 자동 연결하는 스텝 추가
- alias 도메인을 GitHub Secrets(`VERCEL_ALIAS_*_ALPHA`)와 `VERCEL_ALIAS_DOMAIN` env var로 관리하도록 설정

## Links (Issue References, etc, if there's any)

<!-- List related issues or PRs (e.g., Closes #123; Related #456). -->
