### PR TITLE
ks_node: replace Google tokeninfo API with local JWKS verification

### DIFF
--- a/key_share_node/ksn_interface/src/auth.ts
+++ b/key_share_node/ksn_interface/src/auth.ts
@@ -1,22 +1,3 @@
-export interface GoogleTokenInfo {
-  alg: string;
-  at_hash: string;
-  aud: string;
-  azp: string;
-  email: string;
-  email_verified: string;
-  exp: string;
-  family_name: string;
-  given_name: string;
-  iat: string;
-  iss: string;
-  kid: string;
-  name: string;
-  picture: string;
-  sub: string;
-  typ: string;
-}
-
 export interface DiscordTokenInfo {
   id: string;
   username: string;

--- a/key_share_node/server/src/auth/auth0/index.ts
+++ b/key_share_node/server/src/auth/auth0/index.ts
@@ -21,7 +21,7 @@ interface Auth0Jwk extends JsonWebKey {
   kid: string;
 }
 
-const JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+const JWKS_CACHE_TTL_MS = 10 * 60 * 1000;
 const jwksCache = new Map<
   string,
   {

--- a/key_share_node/server/src/auth/google/index.ts
+++ b/key_share_node/server/src/auth/google/index.ts
@@ -23,7 +23,7 @@ interface GoogleJwk extends JsonWebKey {
 
 const GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
 
-const JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+const JWKS_CACHE_TTL_MS = 10 * 60 * 1000;
 const jwksCache = new Map<string, { fetchedAt: number; keys: GoogleJwk[] }>();
 
 export async function validateGoogleOAuthToken(
@@ -122,14 +122,28 @@ export async function validateGoogleOAuthToken(
 }
 
 async function getSigningKey(kid: string): Promise<GoogleJwk | null> {
+  const keys = await fetchJwks();
+  const match = keys.find((k) => k.kid === kid);
+  if (match) {
+    return match;
+  }
+
+  const freshKeys = await fetchJwks({ forceRefresh: true });
+  return freshKeys.find((k) => k.kid === kid) ?? null;
+}
+
+async function fetchJwks(
+  options: { forceRefresh?: boolean } = {},
+): Promise<GoogleJwk[]> {
   const cached = jwksCache.get(GOOGLE_JWKS_URL);
   const now = Date.now();
 
-  if (cached && now - cached.fetchedAt < JWKS_CACHE_TTL_MS) {
-    const match = cached.keys.find((k) => k.kid === kid);
-    if (match) {
-      return match;
-    }
+  if (
+    !options.forceRefresh &&
+    cached &&
+    now - cached.fetchedAt < JWKS_CACHE_TTL_MS
+  ) {
+    return cached.keys;
   }
 
   const response = await fetch(GOOGLE_JWKS_URL);
@@ -146,5 +160,5 @@ async function getSigningKey(kid: string): Promise<GoogleJwk | null> {
 
   jwksCache.set(GOOGLE_JWKS_URL, { fetchedAt: now, keys: body.keys });
 
-  return body.keys.find((k) => k.kid === kid) ?? null;
+  return body.keys;
 }

--- a/key_share_node/server/src/auth/google/index.ts
+++ b/key_share_node/server/src/auth/google/index.ts
@@ -1,63 +1,92 @@
-import type { GoogleTokenInfo } from "@oko-wallet/ksn-interface/auth";
 import type { Result } from "@oko-wallet/stdlib-js";
+import { createPublicKey, type JsonWebKey } from "crypto";
+import jwt, { type JwtHeader, type JwtPayload } from "jsonwebtoken";
 
 import type { OAuthValidationFail } from "../types";
 import { GOOGLE_CLIENT_ID } from "./client_id";
 
-// @TODO: Replace tokeninfo endpoint with JWKS signature verification (RS256).
-// oko_attached and oko_api already use JWKS for both Google and Auth0.
+interface GoogleIdTokenPayload extends JwtPayload {
+  email?: string;
+  email_verified?: boolean;
+  name?: string;
+}
+
+export interface GoogleUserInfo {
+  email: string;
+  sub: string;
+  name?: string;
+}
+
+interface GoogleJwk extends JsonWebKey {
+  kid: string;
+}
+
+const GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
+
+const JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+const jwksCache = new Map<string, { fetchedAt: number; keys: GoogleJwk[] }>();
+
 export async function validateGoogleOAuthToken(
   idToken: string,
-): Promise<Result<GoogleTokenInfo, OAuthValidationFail>> {
+): Promise<Result<GoogleUserInfo, OAuthValidationFail>> {
   try {
-    const res = await fetch(
-      `https://www.googleapis.com/oauth2/v3/tokeninfo?id_token=${idToken}`,
-    );
-    if (!res.ok) {
+    const decoded = jwt.decode(idToken, { complete: true });
+
+    if (!decoded || typeof decoded === "string") {
+      return {
+        success: false,
+        err: { type: "invalid_token", message: "Invalid token format" },
+      };
+    }
+
+    const header = decoded.header as JwtHeader;
+
+    if (!header.kid) {
       return {
         success: false,
         err: {
           type: "invalid_token",
-          message: "Invalid or malformed token",
+          message: "Missing key id in token header",
         },
       };
     }
-    const tokenInfo = (await res.json()) as GoogleTokenInfo;
 
-    if (tokenInfo.aud !== GOOGLE_CLIENT_ID) {
+    const jwk = await getSigningKey(header.kid);
+
+    if (!jwk) {
       return {
         success: false,
         err: {
-          type: "client_id_not_same",
-          message: `Token client ID does not match. expected: ${GOOGLE_CLIENT_ID}, actual: ${tokenInfo.aud}`,
+          type: "invalid_token",
+          message: "Unable to find signing key for token",
         },
       };
     }
 
-    if (
-      tokenInfo.iss !== "https://accounts.google.com" &&
-      tokenInfo.iss !== "https://oauth2.googleapis.com"
-    ) {
+    const publicKey = createPublicKey({ key: jwk, format: "jwk" });
+    const pem = publicKey.export({ type: "spki", format: "pem" }) as string;
+
+    const payload = jwt.verify(idToken, pem, {
+      algorithms: ["RS256"],
+      audience: GOOGLE_CLIENT_ID,
+      issuer: ["https://accounts.google.com", "accounts.google.com"],
+    }) as GoogleIdTokenPayload;
+
+    if (!payload.sub) {
       return {
         success: false,
-        err: {
-          type: "invalid_issuer",
-          message: `Invalid token issuer: ${tokenInfo.iss}`,
-        },
+        err: { type: "invalid_token", message: "Token missing subject claim" },
       };
     }
 
-    if (tokenInfo.exp && Number(tokenInfo.exp) <= Date.now() / 1000) {
+    if (!payload.email) {
       return {
         success: false,
-        err: {
-          type: "token_expired",
-          message: "Token has expired",
-        },
+        err: { type: "invalid_token", message: "Token missing email claim" },
       };
     }
 
-    if (tokenInfo.email_verified !== "true") {
+    if (!payload.email_verified) {
       return {
         success: false,
         err: {
@@ -69,15 +98,53 @@ export async function validateGoogleOAuthToken(
 
     return {
       success: true,
-      data: tokenInfo,
-    };
-  } catch (error: any) {
-    return {
-      success: false,
-      err: {
-        type: "unknown",
-        message: `Token validation failed: ${error instanceof Error ? error.message : String(error)}`,
+      data: {
+        email: payload.email,
+        sub: payload.sub,
+        name: typeof payload.name === "string" ? payload.name : undefined,
       },
     };
+  } catch (error) {
+    if (error instanceof jwt.TokenExpiredError) {
+      return {
+        success: false,
+        err: { type: "token_expired", message: "Token has expired" },
+      };
+    }
+
+    const message =
+      error instanceof Error ? error.message : "Google token validation failed";
+    return {
+      success: false,
+      err: { type: "invalid_token", message },
+    };
   }
+}
+
+async function getSigningKey(kid: string): Promise<GoogleJwk | null> {
+  const cached = jwksCache.get(GOOGLE_JWKS_URL);
+  const now = Date.now();
+
+  if (cached && now - cached.fetchedAt < JWKS_CACHE_TTL_MS) {
+    const match = cached.keys.find((k) => k.kid === kid);
+    if (match) {
+      return match;
+    }
+  }
+
+  const response = await fetch(GOOGLE_JWKS_URL);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Google JWKS: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const body = (await response.json()) as { keys?: GoogleJwk[] };
+  if (!body.keys || !Array.isArray(body.keys) || body.keys.length === 0) {
+    throw new Error("Google JWKS response missing keys");
+  }
+
+  jwksCache.set(GOOGLE_JWKS_URL, { fetchedAt: now, keys: body.keys });
+
+  return body.keys.find((k) => k.kid === kid) ?? null;
 }

--- a/key_share_node/server/src/auth/telegram/validate_jwt.ts
+++ b/key_share_node/server/src/auth/telegram/validate_jwt.ts
@@ -1,6 +1,6 @@
 import type { Result } from "@oko-wallet/stdlib-js";
 import { createPublicKey, type JsonWebKey } from "crypto";
-import jwt, { type JwtHeader, type JwtPayload } from "jsonwebtoken";
+import jwt, { type JwtPayload } from "jsonwebtoken";
 import { Agent } from "undici";
 
 import type { OAuthValidationFail } from "../types";
@@ -27,7 +27,7 @@ interface TelegramIdTokenPayload extends JwtPayload {
   picture?: string;
 }
 
-const JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+const JWKS_CACHE_TTL_MS = 10 * 60 * 1000;
 const jwksCache = new Map<
   string,
   {

--- a/key_share_node/server/src/middlewares/auth.ts
+++ b/key_share_node/server/src/middlewares/auth.ts
@@ -1,7 +1,4 @@
-import type {
-  DiscordTokenInfo,
-  GoogleTokenInfo,
-} from "@oko-wallet/ksn-interface/auth";
+import type { DiscordTokenInfo } from "@oko-wallet/ksn-interface/auth";
 import type { KSNodeApiErrorResponse } from "@oko-wallet/ksn-interface/response";
 import type { AuthType } from "@oko-wallet/oko-types/auth";
 import type { Result } from "@oko-wallet/stdlib-js";
@@ -16,6 +13,7 @@ import {
 } from "@oko-wallet-ksn-server/auth";
 import type { Auth0TokenInfo } from "@oko-wallet-ksn-server/auth/auth0";
 import type { GithubUserInfo } from "@oko-wallet-ksn-server/auth/github";
+import type { GoogleUserInfo } from "@oko-wallet-ksn-server/auth/google";
 import type { TelegramUserInfo } from "@oko-wallet-ksn-server/auth/telegram";
 import type { OAuthValidationFail } from "@oko-wallet-ksn-server/auth/types";
 import type { XUserInfo } from "@oko-wallet-ksn-server/auth/x";
@@ -30,7 +28,7 @@ type OAuthBody = {
 type VerifyResult =
   | {
       auth_type: "google";
-      data: Result<GoogleTokenInfo, OAuthValidationFail>;
+      data: Result<GoogleUserInfo, OAuthValidationFail>;
     }
   | {
       auth_type: "auth0";


### PR DESCRIPTION
# Pull Request

> Thank you for raising a Pull Request. Please follow the instruction.

- [ ] I’ve read `CONTRIBUTING.md` and followed the guidelines.

## Summary

KSN Google 인증을 외부 tokeninfo API 방식에서 로컬 JWKS 서명 검증(RS256) 방식으로 교체

## Links (Issue References, etc, if there's any)

<!-- List related issues or PRs (e.g., Closes #123; Related #456). -->
