### PR TITLE
attached: filter EVM chains with invalid native currency symbol

### DIFF
--- a/embed/oko_attached/src/window_msgs/get_eth_chain_info.ts
+++ b/embed/oko_attached/src/window_msgs/get_eth_chain_info.ts
@@ -27,7 +27,14 @@ export async function handleGetEthChain(
     const chainId = message.payload.chain_id;
 
     const allChains = await getAllChainsCached();
-    const chainInfos = filterEthChains(allChains);
+    // SDK's OkoEIP1193Provider rejects the entire provider construction if any
+    // chain's native currency symbol is outside 1-8 chars. Drop registry
+    // entries that would trip that validator so a single bad chain doesn't
+    // block the whole EVM provider.
+    const chainInfos = filterEthChains(allChains).filter((c) => {
+      const symbol = c.currencies[0]?.coinDenom;
+      return symbol !== undefined && symbol.length >= 1 && symbol.length <= 8;
+    });
 
     let resultChains: ChainInfo[] = [];
 


### PR DESCRIPTION

## Summary

`OkoEIP1193Provider` validates every chain's `nativeCurrency.symbol` against a
1-8 character constraint (`validateNativeCurrencySymbol` in
`sdk/oko_sdk_eth/src/utils/utils.ts`). If a single chain fails, the constructor
throws and the entire EVM provider fails to initialize — breaking `getAccounts`
and downstream wallet flows for every integrator, even on chains they don't use.

The Keplr chain registry currently exposes two EVM entries whose `coinDenom`
exceeds the limit:

- `eip155:1611` — NVNM Mainnet EVM (`MANTRAUSD`, 9 chars)
- `eip155:787111` — NVNM Testnet EVM (`MANTRAUSD`, 9 chars)

These were enough to crash `OkoEthWallet.getEthereumProvider()` on
`app.civitia.org`, which surfaced as Oko "not loading" before Google sign-in.

This hotfix filters such chains out inside `handleGetEthChain` so they never
reach the SDK validator. Only `attached.oko.app` needs to be redeployed —
integrators do not need to ship a new SDK build. A follow-up that hardens the
SDK itself (skipping invalid chains rather than rejecting the whole provider)
can land separately.